### PR TITLE
GH-2: improve Stream and Optional API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 .vscode/
 java_stream.egg-info/
 main.py
+.idea
+*venv*

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,0 +1,14 @@
+## CHANGELIST
+
+### 03-12-21
+
+#### Summary
+
+- Added new orElse and orElseGet API to Optional class
+- Adjusted Stream's findFirst to support predicates
+- Update py docs with newly added API
+- Added new ignorable items
+
+#### Authors
+
+sskorol (Sergey Korol, serhii.s.korol@gmail.com)

--- a/doc/stream/booleans.html
+++ b/doc/stream/booleans.html
@@ -1,328 +1,269 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="generator" content="pdoc 6.3.2" />
-    <title>stream.booleans API documentation</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
-
-
-<style type="text/css">/*! * Bootstrap Reboot v5.0.0-beta1 (https://getbootstrap.com/) * Copyright 2011-2020 The Bootstrap Authors * Copyright 2011-2020 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}[tabindex="-1"]:focus:not(:focus-visible){outline:0!important}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{text-decoration:underline;-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus{outline:dotted 1px;outline:-webkit-focus-ring-color auto 5px}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
-<style type="text/css">/*! pygments syntax highlighting */pre{line-height:125%;}td.linenos pre{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}span.linenos{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}td.linenos pre.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}span.linenos.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}.pdoc .hll{background-color:#ffffcc}.pdoc{background:#f8f8f8;}.pdoc .c{color:#408080; font-style:italic}.pdoc .err{border:1px solid #FF0000}.pdoc .k{color:#008000; font-weight:bold}.pdoc .o{color:#666666}.pdoc .ch{color:#408080; font-style:italic}.pdoc .cm{color:#408080; font-style:italic}.pdoc .cp{color:#BC7A00}.pdoc .cpf{color:#408080; font-style:italic}.pdoc .c1{color:#408080; font-style:italic}.pdoc .cs{color:#408080; font-style:italic}.pdoc .gd{color:#A00000}.pdoc .ge{font-style:italic}.pdoc .gr{color:#FF0000}.pdoc .gh{color:#000080; font-weight:bold}.pdoc .gi{color:#00A000}.pdoc .go{color:#888888}.pdoc .gp{color:#000080; font-weight:bold}.pdoc .gs{font-weight:bold}.pdoc .gu{color:#800080; font-weight:bold}.pdoc .gt{color:#0044DD}.pdoc .kc{color:#008000; font-weight:bold}.pdoc .kd{color:#008000; font-weight:bold}.pdoc .kn{color:#008000; font-weight:bold}.pdoc .kp{color:#008000}.pdoc .kr{color:#008000; font-weight:bold}.pdoc .kt{color:#B00040}.pdoc .m{color:#666666}.pdoc .s{color:#BA2121}.pdoc .na{color:#7D9029}.pdoc .nb{color:#008000}.pdoc .nc{color:#0000FF; font-weight:bold}.pdoc .no{color:#880000}.pdoc .nd{color:#AA22FF}.pdoc .ni{color:#999999; font-weight:bold}.pdoc .ne{color:#D2413A; font-weight:bold}.pdoc .nf{color:#0000FF}.pdoc .nl{color:#A0A000}.pdoc .nn{color:#0000FF; font-weight:bold}.pdoc .nt{color:#008000; font-weight:bold}.pdoc .nv{color:#19177C}.pdoc .ow{color:#AA22FF; font-weight:bold}.pdoc .w{color:#bbbbbb}.pdoc .mb{color:#666666}.pdoc .mf{color:#666666}.pdoc .mh{color:#666666}.pdoc .mi{color:#666666}.pdoc .mo{color:#666666}.pdoc .sa{color:#BA2121}.pdoc .sb{color:#BA2121}.pdoc .sc{color:#BA2121}.pdoc .dl{color:#BA2121}.pdoc .sd{color:#BA2121; font-style:italic}.pdoc .s2{color:#BA2121}.pdoc .se{color:#BB6622; font-weight:bold}.pdoc .sh{color:#BA2121}.pdoc .si{color:#BB6688; font-weight:bold}.pdoc .sx{color:#008000}.pdoc .sr{color:#BB6688}.pdoc .s1{color:#BA2121}.pdoc .ss{color:#19177C}.pdoc .bp{color:#008000}.pdoc .fm{color:#0000FF}.pdoc .vc{color:#19177C}.pdoc .vg{color:#19177C}.pdoc .vi{color:#19177C}.pdoc .vm{color:#19177C}.pdoc .il{color:#666666}</style>
-<style type="text/css">/*! pdoc */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f7f7f7;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}body{background-color:var(--pdoc-background);}html, body{width:100%;height:100%;}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main{padding:2rem 3vw;}.git-button{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}#navtoggle{display:none;}}#togglestate{display:none;}nav.pdoc{--pad:1.75rem;--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc li{display:block;margin:0;padding:.2rem 0 .2rem var(--indent);transition:all 100ms;}nav.pdoc > div > ul > li{padding-left:0;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}html, main{scroll-behavior:smooth;}.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3, .pdoc h4{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{background-color:var(--code);border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.pdoc details{--shift:-40px;text-align:right;margin-top:var(--shift);margin-bottom:calc(0px - var(--shift));clear:both;filter:opacity(1);}.pdoc details:not([open]){height:0;overflow:visible;}.pdoc details > summary{font-size:.75rem;cursor:pointer;color:var(--muted);border-width:0;padding:0 .7em;display:inline-block;display:inline list-item;user-select:none;}.pdoc details > summary:focus{outline:0;}.pdoc details > div{margin-top:calc(0px - var(--shift) / 2);text-align:left;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc > section:first-of-type > .docstring{margin-bottom:3rem;}.pdoc .docstring pre{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc .headerlink{position:absolute;width:0;margin-left:-1.5rem;line-height:1.4rem;font-size:1.5rem;font-weight:normal;transition:all 100ms ease-in-out;opacity:0;}.pdoc .attr > .headerlink{margin-left:-2.5rem;}.pdoc *:hover > .headerlink,.pdoc *:target > .attr > .headerlink{opacity:1;}.pdoc .attr{color:var(--text);margin:1rem 0 .5rem;padding:.4rem 5rem .4rem 1rem;background-color:var(--accent);}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{white-space:pre-wrap;}.pdoc .annotation{color:var(--annotation);}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}</style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>stream.booleans API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
-<body>        <nav class="pdoc">
-            <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
-            <input id="togglestate" type="checkbox">
-            <div>
-                        <a class="pdoc-button module-list-button" href="../stream.html">
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-in-left" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M10 3.5a.5.5 0 0 0-.5-.5h-8a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-2a.5.5 0 0 1 1 0v2A1.5 1.5 0 0 1 9.5 14h-8A1.5 1.5 0 0 1 0 12.5v-9A1.5 1.5 0 0 1 1.5 2h8A1.5 1.5 0 0 1 11 3.5v2a.5.5 0 0 1-1 0v-2z"/>
-  <path fill-rule="evenodd" d="M4.146 8.354a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H14.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3z"/>
-</svg>                            &nbsp;stream</a>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>stream.booleans</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from stream import Stream
+import random
 
 
+class BooleanStream(Stream):
 
+    @staticmethod
+    def random():
+        &#39;&#39;&#39;
+        Returns an infinite stream of random booleans
 
-                    <h2>API Documentation</h2>
-                        <ul class="memberlist">
-            <li>
-                    <a class="class" href="#BooleanStream">BooleanStream</a>
-                            <ul class="memberlist">
-                        <li>
-                                <a class="function" href="#BooleanStream.__init__">BooleanStream</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#BooleanStream.random">random</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#BooleanStream.true">true</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#BooleanStream.false">false</a>
-                        </li>
-                </ul>
+        :return: a random boolean stream
+        &#39;&#39;&#39;
+        return BooleanStream(Stream.generate(lambda: random.randint(0, 1) == 1))
 
-            </li>
-    </ul>
+    @staticmethod
+    def true():
+        &#39;&#39;&#39;
+        Returns an infinite stream of True
 
+        :return: a True boolean stream
+        &#39;&#39;&#39;
+        return BooleanStream(Stream.generate(lambda: True))
 
-                    <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev">
-                        built with <span class="visually-hidden">pdoc</span><img
-                            alt="pdoc logo"
-                            src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
-                    </a>
-            </div>
-        </nav>
-    <main class="pdoc">
-            <section>
-                    <h1 class="modulename">
-<a href="./../stream.html">stream</a>.booleans    </h1>
+    @staticmethod
+    def false():
+        &#39;&#39;&#39;
+        Returns an infinite stream of False
 
-                
-                        <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="kn">from</span> <span class="nn">stream</span> <span class="kn">import</span> <span class="n">Stream</span>
-<span class="kn">import</span> <span class="nn">random</span>
+        :return: a False boolean stream
+        &#39;&#39;&#39;
+        return BooleanStream(Stream.generate(lambda: False))
 
-
-<span class="k">class</span> <span class="nc">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="p">):</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">random</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random booleans</span>
-
-<span class="sd">        :return: a random boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">random</span><span class="o">.</span><span class="n">randint</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">true</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of True</span>
-
-<span class="sd">        :return: a True boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="kc">True</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">false</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of False</span>
-
-<span class="sd">        :return: a False boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="kc">False</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">_stream</span><span class="p">):</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_stream</span><span class="p">,</span> <span class="n">Stream</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span><span class="o">.</span><span class="n">iterable</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span>
-</pre></div>
-
-        </details>
-
-            </section>
-                <section id="BooleanStream">
-                                <div class="attr class">
-        <a class="headerlink" href="#BooleanStream">#&nbsp;&nbsp</a>
-
-        
-        <span class="def">class</span>
-        <span class="name">BooleanStream</span>(<span class="base"><a href="stream.html#Stream">stream.stream.Stream</a></span>):
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="p">):</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">random</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random booleans</span>
-
-<span class="sd">        :return: a random boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">random</span><span class="o">.</span><span class="n">randint</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">true</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of True</span>
-
-<span class="sd">        :return: a True boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="kc">True</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">false</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of False</span>
-
-<span class="sd">        :return: a False boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="kc">False</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">_stream</span><span class="p">):</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_stream</span><span class="p">,</span> <span class="n">Stream</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span><span class="o">.</span><span class="n">iterable</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>A sequence of elements supporting sequential operations.</p>
-
-<p>The following example illustrates an aggregate operation using
-Stream:</p>
-
-<pre><code>result = Stream(elements)
-                .filter(lambda w: w.getColor() == RED)
-                .map(lambda w: w.getWeight())
-                .sum()
-</code></pre>
-
+    def __init__(self, _stream):
+        if isinstance(_stream, Stream):
+            self.iterable = _stream.iterable
+        else:
+            self.iterable = _stream</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="stream.booleans.BooleanStream"><code class="flex name class">
+<span>class <span class="ident">BooleanStream</span></span>
+<span>(</span><span>_stream)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A sequence of elements supporting sequential operations.</p>
+<p>The following example illustrates an aggregate operation using</p>
+<h2 id="stream">Stream</h2>
+<p>result = Stream(elements)
+.filter(lambda w: w.getColor() == RED)
+.map(lambda w: w.getWeight())
+.sum()</p>
 <p>A stream pipeline, like the elements example above, can be viewed as a query on the stream source.</p>
+<p>A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, "forked" streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class BooleanStream(Stream):
 
-<p>A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, "forked" streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</p>
+    @staticmethod
+    def random():
+        &#39;&#39;&#39;
+        Returns an infinite stream of random booleans
+
+        :return: a random boolean stream
+        &#39;&#39;&#39;
+        return BooleanStream(Stream.generate(lambda: random.randint(0, 1) == 1))
+
+    @staticmethod
+    def true():
+        &#39;&#39;&#39;
+        Returns an infinite stream of True
+
+        :return: a True boolean stream
+        &#39;&#39;&#39;
+        return BooleanStream(Stream.generate(lambda: True))
+
+    @staticmethod
+    def false():
+        &#39;&#39;&#39;
+        Returns an infinite stream of False
+
+        :return: a False boolean stream
+        &#39;&#39;&#39;
+        return BooleanStream(Stream.generate(lambda: False))
+
+    def __init__(self, _stream):
+        if isinstance(_stream, Stream):
+            self.iterable = _stream.iterable
+        else:
+            self.iterable = _stream</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="stream.stream.Stream" href="stream.html#stream.stream.Stream">Stream</a></li>
+</ul>
+<h3>Static methods</h3>
+<dl>
+<dt id="stream.booleans.BooleanStream.false"><code class="name flex">
+<span>def <span class="ident">false</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of False</p>
+<p>:return: a False boolean stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def false():
+    &#39;&#39;&#39;
+    Returns an infinite stream of False
+
+    :return: a False boolean stream
+    &#39;&#39;&#39;
+    return BooleanStream(Stream.generate(lambda: False))</code></pre>
+</details>
+</dd>
+<dt id="stream.booleans.BooleanStream.random"><code class="name flex">
+<span>def <span class="ident">random</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of random booleans</p>
+<p>:return: a random boolean stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def random():
+    &#39;&#39;&#39;
+    Returns an infinite stream of random booleans
+
+    :return: a random boolean stream
+    &#39;&#39;&#39;
+    return BooleanStream(Stream.generate(lambda: random.randint(0, 1) == 1))</code></pre>
+</details>
+</dd>
+<dt id="stream.booleans.BooleanStream.true"><code class="name flex">
+<span>def <span class="ident">true</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of True</p>
+<p>:return: a True boolean stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def true():
+    &#39;&#39;&#39;
+    Returns an infinite stream of True
+
+    :return: a True boolean stream
+    &#39;&#39;&#39;
+    return BooleanStream(Stream.generate(lambda: True))</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="stream.stream.Stream" href="stream.html#stream.stream.Stream">Stream</a></b></code>:
+<ul class="hlist">
+<li><code><a title="stream.stream.Stream.allMatch" href="stream.html#stream.stream.Stream.allMatch">allMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.anyMatch" href="stream.html#stream.stream.Stream.anyMatch">anyMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.concat" href="stream.html#stream.stream.Stream.concat">concat</a></code></li>
+<li><code><a title="stream.stream.Stream.constant" href="stream.html#stream.stream.Stream.constant">constant</a></code></li>
+<li><code><a title="stream.stream.Stream.count" href="stream.html#stream.stream.Stream.count">count</a></code></li>
+<li><code><a title="stream.stream.Stream.distinct" href="stream.html#stream.stream.Stream.distinct">distinct</a></code></li>
+<li><code><a title="stream.stream.Stream.dropWhile" href="stream.html#stream.stream.Stream.dropWhile">dropWhile</a></code></li>
+<li><code><a title="stream.stream.Stream.empty" href="stream.html#stream.stream.Stream.empty">empty</a></code></li>
+<li><code><a title="stream.stream.Stream.filter" href="stream.html#stream.stream.Stream.filter">filter</a></code></li>
+<li><code><a title="stream.stream.Stream.findAny" href="stream.html#stream.stream.Stream.findAny">findAny</a></code></li>
+<li><code><a title="stream.stream.Stream.findFirst" href="stream.html#stream.stream.Stream.findFirst">findFirst</a></code></li>
+<li><code><a title="stream.stream.Stream.flatMap" href="stream.html#stream.stream.Stream.flatMap">flatMap</a></code></li>
+<li><code><a title="stream.stream.Stream.forEach" href="stream.html#stream.stream.Stream.forEach">forEach</a></code></li>
+<li><code><a title="stream.stream.Stream.generate" href="stream.html#stream.stream.Stream.generate">generate</a></code></li>
+<li><code><a title="stream.stream.Stream.iterate" href="stream.html#stream.stream.Stream.iterate">iterate</a></code></li>
+<li><code><a title="stream.stream.Stream.limit" href="stream.html#stream.stream.Stream.limit">limit</a></code></li>
+<li><code><a title="stream.stream.Stream.map" href="stream.html#stream.stream.Stream.map">map</a></code></li>
+<li><code><a title="stream.stream.Stream.max" href="stream.html#stream.stream.Stream.max">max</a></code></li>
+<li><code><a title="stream.stream.Stream.min" href="stream.html#stream.stream.Stream.min">min</a></code></li>
+<li><code><a title="stream.stream.Stream.noneMatch" href="stream.html#stream.stream.Stream.noneMatch">noneMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.of" href="stream.html#stream.stream.Stream.of">of</a></code></li>
+<li><code><a title="stream.stream.Stream.ofNullable" href="stream.html#stream.stream.Stream.ofNullable">ofNullable</a></code></li>
+<li><code><a title="stream.stream.Stream.peek" href="stream.html#stream.stream.Stream.peek">peek</a></code></li>
+<li><code><a title="stream.stream.Stream.reduce" href="stream.html#stream.stream.Stream.reduce">reduce</a></code></li>
+<li><code><a title="stream.stream.Stream.skip" href="stream.html#stream.stream.Stream.skip">skip</a></code></li>
+<li><code><a title="stream.stream.Stream.sorted" href="stream.html#stream.stream.Stream.sorted">sorted</a></code></li>
+<li><code><a title="stream.stream.Stream.sum" href="stream.html#stream.stream.Stream.sum">sum</a></code></li>
+<li><code><a title="stream.stream.Stream.takeWhile" href="stream.html#stream.stream.Stream.takeWhile">takeWhile</a></code></li>
+<li><code><a title="stream.stream.Stream.toList" href="stream.html#stream.stream.Stream.toList">toList</a></code></li>
+<li><code><a title="stream.stream.Stream.toSet" href="stream.html#stream.stream.Stream.toSet">toSet</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
 </div>
-
-
-                            <div id="BooleanStream.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#BooleanStream.__init__">#&nbsp;&nbsp</a>
-
-        
-            <span class="name">BooleanStream</span><span class="signature">(_stream)</span>    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">_stream</span><span class="p">):</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_stream</span><span class="p">,</span> <span class="n">Stream</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span><span class="o">.</span><span class="n">iterable</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="BooleanStream.random" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#BooleanStream.random">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">random</span><span class="signature">()</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">random</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random booleans</span>
-
-<span class="sd">        :return: a random boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">random</span><span class="o">.</span><span class="n">randint</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="mi">1</span><span class="p">)</span> <span class="o">==</span> <span class="mi">1</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an infinite stream of random booleans</p>
-
-<p>:return: a random boolean stream</p>
-</div>
-
-
-                            </div>
-                            <div id="BooleanStream.true" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#BooleanStream.true">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">true</span><span class="signature">()</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">true</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of True</span>
-
-<span class="sd">        :return: a True boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="kc">True</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an infinite stream of True</p>
-
-<p>:return: a True boolean stream</p>
-</div>
-
-
-                            </div>
-                            <div id="BooleanStream.false" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#BooleanStream.false">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">false</span><span class="signature">()</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">false</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of False</span>
-
-<span class="sd">        :return: a False boolean stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="kc">False</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an infinite stream of False</p>
-
-<p>:return: a False boolean stream</p>
-</div>
-
-
-                            </div>
-                            <div class="inherited">
-                                <h5>Inherited Members</h5>
-                                <dl>
-                                    <div><dt><a href="stream.html#Stream">stream.stream.Stream</a></dt>
-                                <dd id="BooleanStream.empty" class="function"><a href="stream.html#Stream.empty">empty</a></dd>
-                <dd id="BooleanStream.of" class="function"><a href="stream.html#Stream.of">of</a></dd>
-                <dd id="BooleanStream.ofNullable" class="function"><a href="stream.html#Stream.ofNullable">ofNullable</a></dd>
-                <dd id="BooleanStream.iterate" class="function"><a href="stream.html#Stream.iterate">iterate</a></dd>
-                <dd id="BooleanStream.generate" class="function"><a href="stream.html#Stream.generate">generate</a></dd>
-                <dd id="BooleanStream.concat" class="function"><a href="stream.html#Stream.concat">concat</a></dd>
-                <dd id="BooleanStream.constant" class="function"><a href="stream.html#Stream.constant">constant</a></dd>
-                <dd id="BooleanStream.filter" class="function"><a href="stream.html#Stream.filter">filter</a></dd>
-                <dd id="BooleanStream.map" class="function"><a href="stream.html#Stream.map">map</a></dd>
-                <dd id="BooleanStream.flatMap" class="function"><a href="stream.html#Stream.flatMap">flatMap</a></dd>
-                <dd id="BooleanStream.distinct" class="function"><a href="stream.html#Stream.distinct">distinct</a></dd>
-                <dd id="BooleanStream.limit" class="function"><a href="stream.html#Stream.limit">limit</a></dd>
-                <dd id="BooleanStream.skip" class="function"><a href="stream.html#Stream.skip">skip</a></dd>
-                <dd id="BooleanStream.takeWhile" class="function"><a href="stream.html#Stream.takeWhile">takeWhile</a></dd>
-                <dd id="BooleanStream.dropWhile" class="function"><a href="stream.html#Stream.dropWhile">dropWhile</a></dd>
-                <dd id="BooleanStream.sorted" class="function"><a href="stream.html#Stream.sorted">sorted</a></dd>
-                <dd id="BooleanStream.peek" class="function"><a href="stream.html#Stream.peek">peek</a></dd>
-                <dd id="BooleanStream.forEach" class="function"><a href="stream.html#Stream.forEach">forEach</a></dd>
-                <dd id="BooleanStream.anyMatch" class="function"><a href="stream.html#Stream.anyMatch">anyMatch</a></dd>
-                <dd id="BooleanStream.allMatch" class="function"><a href="stream.html#Stream.allMatch">allMatch</a></dd>
-                <dd id="BooleanStream.noneMatch" class="function"><a href="stream.html#Stream.noneMatch">noneMatch</a></dd>
-                <dd id="BooleanStream.findFirst" class="function"><a href="stream.html#Stream.findFirst">findFirst</a></dd>
-                <dd id="BooleanStream.findAny" class="function"><a href="stream.html#Stream.findAny">findAny</a></dd>
-                <dd id="BooleanStream.reduce" class="function"><a href="stream.html#Stream.reduce">reduce</a></dd>
-                <dd id="BooleanStream.min" class="function"><a href="stream.html#Stream.min">min</a></dd>
-                <dd id="BooleanStream.max" class="function"><a href="stream.html#Stream.max">max</a></dd>
-                <dd id="BooleanStream.sum" class="function"><a href="stream.html#Stream.sum">sum</a></dd>
-                <dd id="BooleanStream.count" class="function"><a href="stream.html#Stream.count">count</a></dd>
-                <dd id="BooleanStream.toList" class="function"><a href="stream.html#Stream.toList">toList</a></dd>
-                <dd id="BooleanStream.toSet" class="function"><a href="stream.html#Stream.toSet">toSet</a></dd>
-                <dd id="BooleanStream.toNumberStream" class="function"><a href="stream.html#Stream.toNumberStream">toNumberStream</a></dd>
-                <dd id="BooleanStream.toBooleanStream" class="function"><a href="stream.html#Stream.toBooleanStream">toBooleanStream</a></dd>
-
-            </div>
-                                </dl>
-                            </div>
-                </section>
-    </main>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="stream" href="index.html">stream</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="stream.booleans.BooleanStream" href="#stream.booleans.BooleanStream">BooleanStream</a></code></h4>
+<ul class="">
+<li><code><a title="stream.booleans.BooleanStream.false" href="#stream.booleans.BooleanStream.false">false</a></code></li>
+<li><code><a title="stream.booleans.BooleanStream.random" href="#stream.booleans.BooleanStream.random">random</a></code></li>
+<li><code><a title="stream.booleans.BooleanStream.true" href="#stream.booleans.BooleanStream.true">true</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
 </body>
 </html>

--- a/doc/stream/index.html
+++ b/doc/stream/index.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>stream API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Package <code>stream</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from .stream import Stream
+from .numbers import NumberStream
+from .booleans import BooleanStream</code></pre>
+</details>
+</section>
+<section>
+<h2 class="section-title" id="header-submodules">Sub-modules</h2>
+<dl>
+<dt><code class="name"><a title="stream.booleans" href="booleans.html">stream.booleans</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="stream.numbers" href="numbers.html">stream.numbers</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="stream.stream" href="stream.html">stream.stream</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="stream.util" href="util/index.html">stream.util</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3><a href="#header-submodules">Sub-modules</a></h3>
+<ul>
+<li><code><a title="stream.booleans" href="booleans.html">stream.booleans</a></code></li>
+<li><code><a title="stream.numbers" href="numbers.html">stream.numbers</a></code></li>
+<li><code><a title="stream.stream" href="stream.html">stream.stream</a></code></li>
+<li><code><a title="stream.util" href="util/index.html">stream.util</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/doc/stream/numbers.html
+++ b/doc/stream/numbers.html
@@ -1,1522 +1,1219 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="generator" content="pdoc 6.3.2" />
-    <title>stream.numbers API documentation</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
-
-
-<style type="text/css">/*! * Bootstrap Reboot v5.0.0-beta1 (https://getbootstrap.com/) * Copyright 2011-2020 The Bootstrap Authors * Copyright 2011-2020 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}[tabindex="-1"]:focus:not(:focus-visible){outline:0!important}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{text-decoration:underline;-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus{outline:dotted 1px;outline:-webkit-focus-ring-color auto 5px}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
-<style type="text/css">/*! pygments syntax highlighting */pre{line-height:125%;}td.linenos pre{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}span.linenos{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}td.linenos pre.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}span.linenos.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}.pdoc .hll{background-color:#ffffcc}.pdoc{background:#f8f8f8;}.pdoc .c{color:#408080; font-style:italic}.pdoc .err{border:1px solid #FF0000}.pdoc .k{color:#008000; font-weight:bold}.pdoc .o{color:#666666}.pdoc .ch{color:#408080; font-style:italic}.pdoc .cm{color:#408080; font-style:italic}.pdoc .cp{color:#BC7A00}.pdoc .cpf{color:#408080; font-style:italic}.pdoc .c1{color:#408080; font-style:italic}.pdoc .cs{color:#408080; font-style:italic}.pdoc .gd{color:#A00000}.pdoc .ge{font-style:italic}.pdoc .gr{color:#FF0000}.pdoc .gh{color:#000080; font-weight:bold}.pdoc .gi{color:#00A000}.pdoc .go{color:#888888}.pdoc .gp{color:#000080; font-weight:bold}.pdoc .gs{font-weight:bold}.pdoc .gu{color:#800080; font-weight:bold}.pdoc .gt{color:#0044DD}.pdoc .kc{color:#008000; font-weight:bold}.pdoc .kd{color:#008000; font-weight:bold}.pdoc .kn{color:#008000; font-weight:bold}.pdoc .kp{color:#008000}.pdoc .kr{color:#008000; font-weight:bold}.pdoc .kt{color:#B00040}.pdoc .m{color:#666666}.pdoc .s{color:#BA2121}.pdoc .na{color:#7D9029}.pdoc .nb{color:#008000}.pdoc .nc{color:#0000FF; font-weight:bold}.pdoc .no{color:#880000}.pdoc .nd{color:#AA22FF}.pdoc .ni{color:#999999; font-weight:bold}.pdoc .ne{color:#D2413A; font-weight:bold}.pdoc .nf{color:#0000FF}.pdoc .nl{color:#A0A000}.pdoc .nn{color:#0000FF; font-weight:bold}.pdoc .nt{color:#008000; font-weight:bold}.pdoc .nv{color:#19177C}.pdoc .ow{color:#AA22FF; font-weight:bold}.pdoc .w{color:#bbbbbb}.pdoc .mb{color:#666666}.pdoc .mf{color:#666666}.pdoc .mh{color:#666666}.pdoc .mi{color:#666666}.pdoc .mo{color:#666666}.pdoc .sa{color:#BA2121}.pdoc .sb{color:#BA2121}.pdoc .sc{color:#BA2121}.pdoc .dl{color:#BA2121}.pdoc .sd{color:#BA2121; font-style:italic}.pdoc .s2{color:#BA2121}.pdoc .se{color:#BB6622; font-weight:bold}.pdoc .sh{color:#BA2121}.pdoc .si{color:#BB6688; font-weight:bold}.pdoc .sx{color:#008000}.pdoc .sr{color:#BB6688}.pdoc .s1{color:#BA2121}.pdoc .ss{color:#19177C}.pdoc .bp{color:#008000}.pdoc .fm{color:#0000FF}.pdoc .vc{color:#19177C}.pdoc .vg{color:#19177C}.pdoc .vi{color:#19177C}.pdoc .vm{color:#19177C}.pdoc .il{color:#666666}</style>
-<style type="text/css">/*! pdoc */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f7f7f7;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}body{background-color:var(--pdoc-background);}html, body{width:100%;height:100%;}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main{padding:2rem 3vw;}.git-button{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}#navtoggle{display:none;}}#togglestate{display:none;}nav.pdoc{--pad:1.75rem;--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc li{display:block;margin:0;padding:.2rem 0 .2rem var(--indent);transition:all 100ms;}nav.pdoc > div > ul > li{padding-left:0;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}html, main{scroll-behavior:smooth;}.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3, .pdoc h4{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{background-color:var(--code);border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.pdoc details{--shift:-40px;text-align:right;margin-top:var(--shift);margin-bottom:calc(0px - var(--shift));clear:both;filter:opacity(1);}.pdoc details:not([open]){height:0;overflow:visible;}.pdoc details > summary{font-size:.75rem;cursor:pointer;color:var(--muted);border-width:0;padding:0 .7em;display:inline-block;display:inline list-item;user-select:none;}.pdoc details > summary:focus{outline:0;}.pdoc details > div{margin-top:calc(0px - var(--shift) / 2);text-align:left;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc > section:first-of-type > .docstring{margin-bottom:3rem;}.pdoc .docstring pre{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc .headerlink{position:absolute;width:0;margin-left:-1.5rem;line-height:1.4rem;font-size:1.5rem;font-weight:normal;transition:all 100ms ease-in-out;opacity:0;}.pdoc .attr > .headerlink{margin-left:-2.5rem;}.pdoc *:hover > .headerlink,.pdoc *:target > .attr > .headerlink{opacity:1;}.pdoc .attr{color:var(--text);margin:1rem 0 .5rem;padding:.4rem 5rem .4rem 1rem;background-color:var(--accent);}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{white-space:pre-wrap;}.pdoc .annotation{color:var(--annotation);}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}</style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>stream.numbers API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
-<body>        <nav class="pdoc">
-            <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
-            <input id="togglestate" type="checkbox">
-            <div>
-                        <a class="pdoc-button module-list-button" href="../stream.html">
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-in-left" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M10 3.5a.5.5 0 0 0-.5-.5h-8a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-2a.5.5 0 0 1 1 0v2A1.5 1.5 0 0 1 9.5 14h-8A1.5 1.5 0 0 1 0 12.5v-9A1.5 1.5 0 0 1 1.5 2h8A1.5 1.5 0 0 1 11 3.5v2a.5.5 0 0 1-1 0v-2z"/>
-  <path fill-rule="evenodd" d="M4.146 8.354a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H14.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3z"/>
-</svg>                            &nbsp;stream</a>
-
-
-
-
-                    <h2>API Documentation</h2>
-                        <ul class="memberlist">
-            <li>
-                    <a class="class" href="#NumberStream">NumberStream</a>
-                            <ul class="memberlist">
-                        <li>
-                                <a class="function" href="#NumberStream.__init__">NumberStream</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.integers">integers</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.odds">odds</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.evens">evens</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.primes">primes</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.randint">randint</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.random">random</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.range">range</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.pi">pi</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.average">average</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.takeWhileSmallerThan">takeWhileSmallerThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.takeWhileSmallerOrEqualThan">takeWhileSmallerOrEqualThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.takeWhileGreaterThan">takeWhileGreaterThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.takeWhileGreaterOrEqualThan">takeWhileGreaterOrEqualThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.smallerThan">smallerThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.smallerOrEqualThan">smallerOrEqualThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.greaterThan">greaterThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.greaterOrEqualThan">greaterOrEqualThan</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.multipleOf">multipleOf</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.square">square</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.cube">cube</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.pow">pow</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.sqrt">sqrt</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.log">log</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.sin">sin</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#NumberStream.cos">cos</a>
-                        </li>
-                </ul>
-
-            </li>
-    </ul>
-
-
-                    <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev">
-                        built with <span class="visually-hidden">pdoc</span><img
-                            alt="pdoc logo"
-                            src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
-                    </a>
-            </div>
-        </nav>
-    <main class="pdoc">
-            <section>
-                    <h1 class="modulename">
-<a href="./../stream.html">stream</a>.numbers    </h1>
-
-                
-                        <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="kn">import</span> <span class="nn">math</span>
-<span class="kn">import</span> <span class="nn">random</span>
-
-<span class="kn">from</span> <span class="nn">.stream</span> <span class="kn">import</span> <span class="n">Stream</span>
-
-
-<span class="k">class</span> <span class="nc">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="p">):</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">integers</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of integer from 0 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">odds</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of odds number from 0 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">2</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">evens</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of evens number from 0 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">2</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">primes</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of primes number from 2 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">def</span> <span class="nf">prime_generator</span><span class="p">():</span>
-            <span class="k">yield</span> <span class="mi">2</span>
-            <span class="n">primes</span> <span class="o">=</span> <span class="p">[</span><span class="mi">2</span><span class="p">]</span>
-            <span class="n">actual</span> <span class="o">=</span> <span class="mi">1</span>
-            <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
-                <span class="n">actual</span> <span class="o">+=</span> <span class="mi">2</span>
-                <span class="k">for</span> <span class="n">prime</span> <span class="ow">in</span> <span class="n">primes</span><span class="p">:</span>
-                    <span class="k">if</span> <span class="n">actual</span> <span class="o">%</span> <span class="n">prime</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-                        <span class="k">break</span>
-                <span class="k">else</span><span class="p">:</span>
-                    <span class="n">primes</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">actual</span><span class="p">)</span>
-                    <span class="k">yield</span> <span class="n">actual</span>
-
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">prime_generator</span><span class="p">())</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">randint</span><span class="p">(</span><span class="n">lower</span><span class="p">,</span> <span class="n">upper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random integer in range [a, b], including both end points.</span>
-
-<span class="sd">        :param int lower: min value for random numbers</span>
-<span class="sd">        :param int upper: max value for random numbers</span>
-<span class="sd">        :return: the infinite random stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">random</span><span class="o">.</span><span class="n">randint</span><span class="p">(</span><span class="n">lower</span><span class="p">,</span> <span class="n">upper</span><span class="p">)))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">random</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random numbers in range [0, 1], including both end points.</span>
-
-<span class="sd">        :param int lower: min value for random numbers</span>
-<span class="sd">        :param int upper: max value for random numbers</span>
-<span class="sd">        :return: the infinite random stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="n">random</span><span class="o">.</span><span class="n">random</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">range</span><span class="p">(</span><span class="n">start</span><span class="p">,</span> <span class="n">end</span><span class="p">,</span> <span class="n">step</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream of numbers from start to end with specified step.</span>
-
-<span class="sd">        :param int start: the start value</span>
-<span class="sd">        :param int end: the max value</span>
-<span class="sd">        :param int step: the step</span>
-<span class="sd">        :return: the new stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="n">start</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="n">step</span><span class="p">)</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">end</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">pi</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream with the digits of PI.</span>
-
-<span class="sd">        :return: the PI&#39;s digits stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">def</span> <span class="nf">pi_digits</span><span class="p">():</span>
-            <span class="s2">&quot;Generate n digits of Pi.&quot;</span>
-            <span class="n">k</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span> <span class="o">=</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">4</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">12</span><span class="p">,</span> <span class="mi">4</span>
-            <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
-                <span class="n">p</span><span class="p">,</span> <span class="n">q</span><span class="p">,</span> <span class="n">k</span> <span class="o">=</span> <span class="n">k</span> <span class="o">*</span> <span class="n">k</span><span class="p">,</span> <span class="mi">2</span> <span class="o">*</span> <span class="n">k</span> <span class="o">+</span> <span class="mi">1</span><span class="p">,</span> <span class="n">k</span> <span class="o">+</span> <span class="mi">1</span>
-                <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span> <span class="o">=</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span><span class="p">,</span> <span class="n">p</span> <span class="o">*</span> <span class="n">a</span> <span class="o">+</span> <span class="n">q</span> <span class="o">*</span> <span class="n">a1</span><span class="p">,</span> <span class="n">p</span> <span class="o">*</span> <span class="n">b</span> <span class="o">+</span> <span class="n">q</span> <span class="o">*</span> <span class="n">b1</span>
-                <span class="n">d</span><span class="p">,</span> <span class="n">d1</span> <span class="o">=</span> <span class="n">a</span> <span class="o">/</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span> <span class="o">/</span> <span class="n">b1</span>
-                <span class="k">while</span> <span class="n">d</span> <span class="o">==</span> <span class="n">d1</span><span class="p">:</span>
-                    <span class="k">yield</span> <span class="nb">int</span><span class="p">(</span><span class="n">d</span><span class="p">)</span>
-                    <span class="n">a</span><span class="p">,</span> <span class="n">a1</span> <span class="o">=</span> <span class="mi">10</span> <span class="o">*</span> <span class="p">(</span><span class="n">a</span> <span class="o">%</span> <span class="n">b</span><span class="p">),</span> <span class="mi">10</span> <span class="o">*</span> <span class="p">(</span><span class="n">a1</span> <span class="o">%</span> <span class="n">b1</span><span class="p">)</span>
-                    <span class="n">d</span><span class="p">,</span> <span class="n">d1</span> <span class="o">=</span> <span class="n">a</span> <span class="o">/</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span> <span class="o">/</span> <span class="n">b1</span>
-
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="p">(</span><span class="n">pi_digits</span><span class="p">()))</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">_stream</span><span class="p">):</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_stream</span><span class="p">,</span> <span class="n">Stream</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span><span class="o">.</span><span class="n">iterable</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span>
-
-    <span class="k">def</span> <span class="nf">average</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Get the average value of the element of the stream.</span>
-
-<span class="sd">        :return: the average value</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">_sum</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="n">_count</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="p">:</span>
-            <span class="n">_sum</span> <span class="o">+=</span> <span class="n">elem</span>
-            <span class="n">_count</span> <span class="o">+=</span> <span class="mi">1</span>
-        <span class="k">return</span> <span class="n">_sum</span> <span class="o">/</span> <span class="n">_count</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileSmallerThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileSmallerOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileGreaterThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileGreaterOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;=</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">smallerThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are smaller than the specified value</span>
-
-<span class="sd">        :param int maximum: the maximum value [exclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">smallerOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value</span>
-
-<span class="sd">        :param int maximum: the maximum value [inclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">greaterThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are greater than the specified value</span>
-
-<span class="sd">        :param int minimum: the minimum value [exclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">greaterOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are greater than the specified value</span>
-
-<span class="sd">        :param int minimum: the minimum value [inclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;=</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">multipleOf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">number</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are multiple of the specified value</span>
-
-<span class="sd">        :param int number: the value</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">%</span> <span class="n">number</span> <span class="o">==</span> <span class="mi">0</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">square</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the square of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pow</span><span class="p">(</span><span class="mi">2</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">cube</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the cube of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pow</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">pow</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">power</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the pow to the specified value of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">**</span> <span class="n">power</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">sqrt</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the square root of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">sqrt</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">log</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the log of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">log</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">sin</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the sin of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">sin</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">cos</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the cos of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">cos</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            </section>
-                <section id="NumberStream">
-                                <div class="attr class">
-        <a class="headerlink" href="#NumberStream">#&nbsp;&nbsp</a>
-
-        
-        <span class="def">class</span>
-        <span class="name">NumberStream</span>(<span class="base"><a href="stream.html#Stream">stream.stream.Stream</a></span>):
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="p">):</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">integers</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of integer from 0 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">odds</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of odds number from 0 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">2</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">evens</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of evens number from 0 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">2</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">primes</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of primes number from 2 to infinity</span>
-
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">def</span> <span class="nf">prime_generator</span><span class="p">():</span>
-            <span class="k">yield</span> <span class="mi">2</span>
-            <span class="n">primes</span> <span class="o">=</span> <span class="p">[</span><span class="mi">2</span><span class="p">]</span>
-            <span class="n">actual</span> <span class="o">=</span> <span class="mi">1</span>
-            <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
-                <span class="n">actual</span> <span class="o">+=</span> <span class="mi">2</span>
-                <span class="k">for</span> <span class="n">prime</span> <span class="ow">in</span> <span class="n">primes</span><span class="p">:</span>
-                    <span class="k">if</span> <span class="n">actual</span> <span class="o">%</span> <span class="n">prime</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-                        <span class="k">break</span>
-                <span class="k">else</span><span class="p">:</span>
-                    <span class="n">primes</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">actual</span><span class="p">)</span>
-                    <span class="k">yield</span> <span class="n">actual</span>
-
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">prime_generator</span><span class="p">())</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">randint</span><span class="p">(</span><span class="n">lower</span><span class="p">,</span> <span class="n">upper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random integer in range [a, b], including both end points.</span>
-
-<span class="sd">        :param int lower: min value for random numbers</span>
-<span class="sd">        :param int upper: max value for random numbers</span>
-<span class="sd">        :return: the infinite random stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">random</span><span class="o">.</span><span class="n">randint</span><span class="p">(</span><span class="n">lower</span><span class="p">,</span> <span class="n">upper</span><span class="p">)))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">random</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random numbers in range [0, 1], including both end points.</span>
-
-<span class="sd">        :param int lower: min value for random numbers</span>
-<span class="sd">        :param int upper: max value for random numbers</span>
-<span class="sd">        :return: the infinite random stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="n">random</span><span class="o">.</span><span class="n">random</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">range</span><span class="p">(</span><span class="n">start</span><span class="p">,</span> <span class="n">end</span><span class="p">,</span> <span class="n">step</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream of numbers from start to end with specified step.</span>
-
-<span class="sd">        :param int start: the start value</span>
-<span class="sd">        :param int end: the max value</span>
-<span class="sd">        :param int step: the step</span>
-<span class="sd">        :return: the new stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="n">start</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="n">step</span><span class="p">)</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">end</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">pi</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream with the digits of PI.</span>
-
-<span class="sd">        :return: the PI&#39;s digits stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">def</span> <span class="nf">pi_digits</span><span class="p">():</span>
-            <span class="s2">&quot;Generate n digits of Pi.&quot;</span>
-            <span class="n">k</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span> <span class="o">=</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">4</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">12</span><span class="p">,</span> <span class="mi">4</span>
-            <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
-                <span class="n">p</span><span class="p">,</span> <span class="n">q</span><span class="p">,</span> <span class="n">k</span> <span class="o">=</span> <span class="n">k</span> <span class="o">*</span> <span class="n">k</span><span class="p">,</span> <span class="mi">2</span> <span class="o">*</span> <span class="n">k</span> <span class="o">+</span> <span class="mi">1</span><span class="p">,</span> <span class="n">k</span> <span class="o">+</span> <span class="mi">1</span>
-                <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span> <span class="o">=</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span><span class="p">,</span> <span class="n">p</span> <span class="o">*</span> <span class="n">a</span> <span class="o">+</span> <span class="n">q</span> <span class="o">*</span> <span class="n">a1</span><span class="p">,</span> <span class="n">p</span> <span class="o">*</span> <span class="n">b</span> <span class="o">+</span> <span class="n">q</span> <span class="o">*</span> <span class="n">b1</span>
-                <span class="n">d</span><span class="p">,</span> <span class="n">d1</span> <span class="o">=</span> <span class="n">a</span> <span class="o">/</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span> <span class="o">/</span> <span class="n">b1</span>
-                <span class="k">while</span> <span class="n">d</span> <span class="o">==</span> <span class="n">d1</span><span class="p">:</span>
-                    <span class="k">yield</span> <span class="nb">int</span><span class="p">(</span><span class="n">d</span><span class="p">)</span>
-                    <span class="n">a</span><span class="p">,</span> <span class="n">a1</span> <span class="o">=</span> <span class="mi">10</span> <span class="o">*</span> <span class="p">(</span><span class="n">a</span> <span class="o">%</span> <span class="n">b</span><span class="p">),</span> <span class="mi">10</span> <span class="o">*</span> <span class="p">(</span><span class="n">a1</span> <span class="o">%</span> <span class="n">b1</span><span class="p">)</span>
-                    <span class="n">d</span><span class="p">,</span> <span class="n">d1</span> <span class="o">=</span> <span class="n">a</span> <span class="o">/</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span> <span class="o">/</span> <span class="n">b1</span>
-
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="p">(</span><span class="n">pi_digits</span><span class="p">()))</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">_stream</span><span class="p">):</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_stream</span><span class="p">,</span> <span class="n">Stream</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span><span class="o">.</span><span class="n">iterable</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span>
-
-    <span class="k">def</span> <span class="nf">average</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Get the average value of the element of the stream.</span>
-
-<span class="sd">        :return: the average value</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">_sum</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="n">_count</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="p">:</span>
-            <span class="n">_sum</span> <span class="o">+=</span> <span class="n">elem</span>
-            <span class="n">_count</span> <span class="o">+=</span> <span class="mi">1</span>
-        <span class="k">return</span> <span class="n">_sum</span> <span class="o">/</span> <span class="n">_count</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileSmallerThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileSmallerOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileGreaterThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">takeWhileGreaterOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;=</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">smallerThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are smaller than the specified value</span>
-
-<span class="sd">        :param int maximum: the maximum value [exclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">smallerOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value</span>
-
-<span class="sd">        :param int maximum: the maximum value [inclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">maximum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">greaterThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are greater than the specified value</span>
-
-<span class="sd">        :param int minimum: the minimum value [exclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">greaterOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are greater than the specified value</span>
-
-<span class="sd">        :param int minimum: the minimum value [inclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;=</span> <span class="n">minimum</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">multipleOf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">number</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are multiple of the specified value</span>
-
-<span class="sd">        :param int number: the value</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">%</span> <span class="n">number</span> <span class="o">==</span> <span class="mi">0</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">square</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the square of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pow</span><span class="p">(</span><span class="mi">2</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">cube</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the cube of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pow</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">pow</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">power</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the pow to the specified value of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">**</span> <span class="n">power</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">sqrt</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the square root of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">sqrt</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">log</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the log of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">log</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">sin</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the sin of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">sin</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">cos</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the cos of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">cos</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>A sequence of elements supporting sequential operations.</p>
-
-<p>The following example illustrates an aggregate operation using
-Stream:</p>
-
-<pre><code>result = Stream(elements)
-                .filter(lambda w: w.getColor() == RED)
-                .map(lambda w: w.getWeight())
-                .sum()
-</code></pre>
-
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>stream.numbers</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">import math
+import random
+
+from .stream import Stream
+
+
+class NumberStream(Stream):
+
+    @staticmethod
+    def integers():
+        &#39;&#39;&#39;
+        Returns an infinite stream of integer from 0 to infinity
+
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(0, lambda i: i + 1))
+
+    @staticmethod
+    def odds():
+        &#39;&#39;&#39;
+        Returns an infinite stream of odds number from 0 to infinity
+
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(1, lambda i: i + 2))
+
+    @staticmethod
+    def evens():
+        &#39;&#39;&#39;
+        Returns an infinite stream of evens number from 0 to infinity
+
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(0, lambda i: i + 2))
+
+    @staticmethod
+    def primes():
+        &#39;&#39;&#39;
+        Returns an infinite stream of primes number from 2 to infinity
+
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        def prime_generator():
+            yield 2
+            primes = [2]
+            actual = 1
+            while True:
+                actual += 2
+                for prime in primes:
+                    if actual % prime == 0:
+                        break
+                else:
+                    primes.append(actual)
+                    yield actual
+
+        return NumberStream(prime_generator())
+
+    @staticmethod
+    def randint(lower, upper):
+        &#39;&#39;&#39;
+        Returns an infinite stream of random integer in range [a, b], including both end points.
+
+        :param int lower: min value for random numbers
+        :param int upper: max value for random numbers
+        :return: the infinite random stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.generate(lambda: random.randint(lower, upper)))
+
+    @staticmethod
+    def random():
+        &#39;&#39;&#39;
+        Returns an infinite stream of random numbers in range [0, 1], including both end points.
+
+        :param int lower: min value for random numbers
+        :param int upper: max value for random numbers
+        :return: the infinite random stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.generate(random.random))
+
+    @staticmethod
+    def range(start, end, step=1):
+        &#39;&#39;&#39;
+        Returns a stream of numbers from start to end with specified step.
+
+        :param int start: the start value
+        :param int end: the max value
+        :param int step: the step
+        :return: the new stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(start, lambda i: i + step).takeWhile(lambda x: x &lt;= end))
+
+    @staticmethod
+    def pi():
+        &#39;&#39;&#39;
+        Returns a stream with the digits of PI.
+
+        :return: the PI&#39;s digits stream
+        &#39;&#39;&#39;
+        def pi_digits():
+            &#34;Generate n digits of Pi.&#34;
+            k, a, b, a1, b1 = 2, 4, 1, 12, 4
+            while True:
+                p, q, k = k * k, 2 * k + 1, k + 1
+                a, b, a1, b1 = a1, b1, p * a + q * a1, p * b + q * b1
+                d, d1 = a / b, a1 / b1
+                while d == d1:
+                    yield int(d)
+                    a, a1 = 10 * (a % b), 10 * (a1 % b1)
+                    d, d1 = a / b, a1 / b1
+
+        return NumberStream(Stream(pi_digits()))
+
+    def __init__(self, _stream):
+        if isinstance(_stream, Stream):
+            self.iterable = _stream.iterable
+        else:
+            self.iterable = _stream
+
+    def average(self):
+        &#39;&#39;&#39;
+        Get the average value of the element of the stream.
+
+        :return: the average value
+        &#39;&#39;&#39;
+        _sum = 0
+        _count = 0
+        for elem in self:
+            _sum += elem
+            _count += 1
+        return _sum / _count
+
+    def takeWhileSmallerThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &lt; maximum)
+
+    def takeWhileSmallerOrEqualThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &lt;= maximum)
+
+    def takeWhileGreaterThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &gt; minimum)
+
+    def takeWhileGreaterOrEqualThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &gt;= minimum)
+
+    def smallerThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are smaller than the specified value
+
+        :param int maximum: the maximum value [exclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &lt; maximum)
+
+    def smallerOrEqualThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value
+
+        :param int maximum: the maximum value [inclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &lt;= maximum)
+
+    def greaterThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are greater than the specified value
+
+        :param int minimum: the minimum value [exclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &gt; minimum)
+
+    def greaterOrEqualThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are greater than the specified value
+
+        :param int minimum: the minimum value [inclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &gt;= minimum)
+
+    def multipleOf(self, number):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are multiple of the specified value
+
+        :param int number: the value
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x % number == 0)
+
+    def square(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the square of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.pow(2)
+
+    def cube(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the cube of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.pow(3)
+
+    def pow(self, power):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the pow to the specified value of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(lambda x: x ** power)
+
+    def sqrt(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the square root of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.sqrt)
+
+    def log(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the log of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.log)
+
+    def sin(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the sin of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.sin)
+
+    def cos(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the cos of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.cos)</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="stream.numbers.NumberStream"><code class="flex name class">
+<span>class <span class="ident">NumberStream</span></span>
+<span>(</span><span>_stream)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A sequence of elements supporting sequential operations.</p>
+<p>The following example illustrates an aggregate operation using</p>
+<h2 id="stream">Stream</h2>
+<p>result = Stream(elements)
+.filter(lambda w: w.getColor() == RED)
+.map(lambda w: w.getWeight())
+.sum()</p>
 <p>A stream pipeline, like the elements example above, can be viewed as a query on the stream source.</p>
+<p>A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, "forked" streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class NumberStream(Stream):
 
-<p>A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, "forked" streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</p>
-</div>
+    @staticmethod
+    def integers():
+        &#39;&#39;&#39;
+        Returns an infinite stream of integer from 0 to infinity
 
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(0, lambda i: i + 1))
 
-                            <div id="NumberStream.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.__init__">#&nbsp;&nbsp</a>
+    @staticmethod
+    def odds():
+        &#39;&#39;&#39;
+        Returns an infinite stream of odds number from 0 to infinity
 
-        
-            <span class="name">NumberStream</span><span class="signature">(_stream)</span>    </div>
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(1, lambda i: i + 2))
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">_stream</span><span class="p">):</span>
-        <span class="k">if</span> <span class="nb">isinstance</span><span class="p">(</span><span class="n">_stream</span><span class="p">,</span> <span class="n">Stream</span><span class="p">):</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span><span class="o">.</span><span class="n">iterable</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">_stream</span>
-</pre></div>
+    @staticmethod
+    def evens():
+        &#39;&#39;&#39;
+        Returns an infinite stream of evens number from 0 to infinity
 
-        </details>
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(0, lambda i: i + 2))
 
-    
+    @staticmethod
+    def primes():
+        &#39;&#39;&#39;
+        Returns an infinite stream of primes number from 2 to infinity
 
-                            </div>
-                            <div id="NumberStream.integers" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.integers">#&nbsp;&nbsp</a>
+        :return: the infinite stream
+        &#39;&#39;&#39;
+        def prime_generator():
+            yield 2
+            primes = [2]
+            actual = 1
+            while True:
+                actual += 2
+                for prime in primes:
+                    if actual % prime == 0:
+                        break
+                else:
+                    primes.append(actual)
+                    yield actual
 
-                <div class="decorator">@staticmethod</div>
+        return NumberStream(prime_generator())
 
-            <span class="def">def</span>
-            <span class="name">integers</span><span class="signature">()</span>:
-    </div>
+    @staticmethod
+    def randint(lower, upper):
+        &#39;&#39;&#39;
+        Returns an infinite stream of random integer in range [a, b], including both end points.
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">integers</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of integer from 0 to infinity</span>
+        :param int lower: min value for random numbers
+        :param int upper: max value for random numbers
+        :return: the infinite random stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.generate(lambda: random.randint(lower, upper)))
 
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">1</span><span class="p">))</span>
-</pre></div>
+    @staticmethod
+    def random():
+        &#39;&#39;&#39;
+        Returns an infinite stream of random numbers in range [0, 1], including both end points.
 
-        </details>
+        :param int lower: min value for random numbers
+        :param int upper: max value for random numbers
+        :return: the infinite random stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.generate(random.random))
 
-            <div class="docstring"><p>Returns an infinite stream of integer from 0 to infinity</p>
+    @staticmethod
+    def range(start, end, step=1):
+        &#39;&#39;&#39;
+        Returns a stream of numbers from start to end with specified step.
 
-<p>:return: the infinite stream</p>
-</div>
+        :param int start: the start value
+        :param int end: the max value
+        :param int step: the step
+        :return: the new stream
+        &#39;&#39;&#39;
+        return NumberStream(Stream.iterate(start, lambda i: i + step).takeWhile(lambda x: x &lt;= end))
 
+    @staticmethod
+    def pi():
+        &#39;&#39;&#39;
+        Returns a stream with the digits of PI.
 
-                            </div>
-                            <div id="NumberStream.odds" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.odds">#&nbsp;&nbsp</a>
+        :return: the PI&#39;s digits stream
+        &#39;&#39;&#39;
+        def pi_digits():
+            &#34;Generate n digits of Pi.&#34;
+            k, a, b, a1, b1 = 2, 4, 1, 12, 4
+            while True:
+                p, q, k = k * k, 2 * k + 1, k + 1
+                a, b, a1, b1 = a1, b1, p * a + q * a1, p * b + q * b1
+                d, d1 = a / b, a1 / b1
+                while d == d1:
+                    yield int(d)
+                    a, a1 = 10 * (a % b), 10 * (a1 % b1)
+                    d, d1 = a / b, a1 / b1
 
-                <div class="decorator">@staticmethod</div>
+        return NumberStream(Stream(pi_digits()))
 
-            <span class="def">def</span>
-            <span class="name">odds</span><span class="signature">()</span>:
-    </div>
+    def __init__(self, _stream):
+        if isinstance(_stream, Stream):
+            self.iterable = _stream.iterable
+        else:
+            self.iterable = _stream
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">odds</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of odds number from 0 to infinity</span>
+    def average(self):
+        &#39;&#39;&#39;
+        Get the average value of the element of the stream.
 
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">2</span><span class="p">))</span>
-</pre></div>
+        :return: the average value
+        &#39;&#39;&#39;
+        _sum = 0
+        _count = 0
+        for elem in self:
+            _sum += elem
+            _count += 1
+        return _sum / _count
 
-        </details>
+    def takeWhileSmallerThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value
 
-            <div class="docstring"><p>Returns an infinite stream of odds number from 0 to infinity</p>
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &lt; maximum)
 
-<p>:return: the infinite stream</p>
-</div>
+    def takeWhileSmallerOrEqualThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value
 
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &lt;= maximum)
 
-                            </div>
-                            <div id="NumberStream.evens" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.evens">#&nbsp;&nbsp</a>
+    def takeWhileGreaterThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value
 
-                <div class="decorator">@staticmethod</div>
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &gt; minimum)
 
-            <span class="def">def</span>
-            <span class="name">evens</span><span class="signature">()</span>:
-    </div>
+    def takeWhileGreaterOrEqualThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">evens</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of evens number from 0 to infinity</span>
+        :return: self
+        &#39;&#39;&#39;
+        return self.takeWhile(lambda x: x &gt;= minimum)
 
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="mi">0</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="mi">2</span><span class="p">))</span>
-</pre></div>
+    def smallerThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are smaller than the specified value
 
-        </details>
+        :param int maximum: the maximum value [exclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &lt; maximum)
 
-            <div class="docstring"><p>Returns an infinite stream of evens number from 0 to infinity</p>
+    def smallerOrEqualThan(self, maximum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value
 
-<p>:return: the infinite stream</p>
-</div>
+        :param int maximum: the maximum value [inclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &lt;= maximum)
 
+    def greaterThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are greater than the specified value
 
-                            </div>
-                            <div id="NumberStream.primes" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.primes">#&nbsp;&nbsp</a>
+        :param int minimum: the minimum value [exclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &gt; minimum)
 
-                <div class="decorator">@staticmethod</div>
+    def greaterOrEqualThan(self, minimum):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are greater than the specified value
 
-            <span class="def">def</span>
-            <span class="name">primes</span><span class="signature">()</span>:
-    </div>
+        :param int minimum: the minimum value [inclusive]
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x &gt;= minimum)
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">primes</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of primes number from 2 to infinity</span>
+    def multipleOf(self, number):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream that are multiple of the specified value
 
-<span class="sd">        :return: the infinite stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">def</span> <span class="nf">prime_generator</span><span class="p">():</span>
-            <span class="k">yield</span> <span class="mi">2</span>
-            <span class="n">primes</span> <span class="o">=</span> <span class="p">[</span><span class="mi">2</span><span class="p">]</span>
-            <span class="n">actual</span> <span class="o">=</span> <span class="mi">1</span>
-            <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
-                <span class="n">actual</span> <span class="o">+=</span> <span class="mi">2</span>
-                <span class="k">for</span> <span class="n">prime</span> <span class="ow">in</span> <span class="n">primes</span><span class="p">:</span>
-                    <span class="k">if</span> <span class="n">actual</span> <span class="o">%</span> <span class="n">prime</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-                        <span class="k">break</span>
-                <span class="k">else</span><span class="p">:</span>
-                    <span class="n">primes</span><span class="o">.</span><span class="n">append</span><span class="p">(</span><span class="n">actual</span><span class="p">)</span>
-                    <span class="k">yield</span> <span class="n">actual</span>
+        :param int number: the value
+        :return: self
+        &#39;&#39;&#39;
+        return self.filter(lambda x: x % number == 0)
 
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">prime_generator</span><span class="p">())</span>
-</pre></div>
+    def square(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the square of the element of this stream
 
-        </details>
+        :return: self
+        &#39;&#39;&#39;
+        return self.pow(2)
 
-            <div class="docstring"><p>Returns an infinite stream of primes number from 2 to infinity</p>
+    def cube(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the cube of the element of this stream
 
-<p>:return: the infinite stream</p>
-</div>
+        :return: self
+        &#39;&#39;&#39;
+        return self.pow(3)
 
+    def pow(self, power):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the pow to the specified value of the element of this stream
 
-                            </div>
-                            <div id="NumberStream.randint" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.randint">#&nbsp;&nbsp</a>
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(lambda x: x ** power)
 
-                <div class="decorator">@staticmethod</div>
+    def sqrt(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the square root of the element of this stream
 
-            <span class="def">def</span>
-            <span class="name">randint</span><span class="signature">(lower, upper)</span>:
-    </div>
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.sqrt)
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">randint</span><span class="p">(</span><span class="n">lower</span><span class="p">,</span> <span class="n">upper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random integer in range [a, b], including both end points.</span>
+    def log(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the log of the element of this stream
 
-<span class="sd">        :param int lower: min value for random numbers</span>
-<span class="sd">        :param int upper: max value for random numbers</span>
-<span class="sd">        :return: the infinite random stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">random</span><span class="o">.</span><span class="n">randint</span><span class="p">(</span><span class="n">lower</span><span class="p">,</span> <span class="n">upper</span><span class="p">)))</span>
-</pre></div>
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.log)
 
-        </details>
+    def sin(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the sin of the element of this stream
 
-            <div class="docstring"><p>Returns an infinite stream of random integer in range [a, b], including both end points.</p>
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.sin)
 
+    def cos(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the cos of the element of this stream
+
+        :return: self
+        &#39;&#39;&#39;
+        return self.map(math.cos)</code></pre>
+</details>
+<h3>Ancestors</h3>
+<ul class="hlist">
+<li><a title="stream.stream.Stream" href="stream.html#stream.stream.Stream">Stream</a></li>
+</ul>
+<h3>Static methods</h3>
+<dl>
+<dt id="stream.numbers.NumberStream.evens"><code class="name flex">
+<span>def <span class="ident">evens</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of evens number from 0 to infinity</p>
+<p>:return: the infinite stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def evens():
+    &#39;&#39;&#39;
+    Returns an infinite stream of evens number from 0 to infinity
+
+    :return: the infinite stream
+    &#39;&#39;&#39;
+    return NumberStream(Stream.iterate(0, lambda i: i + 2))</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.integers"><code class="name flex">
+<span>def <span class="ident">integers</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of integer from 0 to infinity</p>
+<p>:return: the infinite stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def integers():
+    &#39;&#39;&#39;
+    Returns an infinite stream of integer from 0 to infinity
+
+    :return: the infinite stream
+    &#39;&#39;&#39;
+    return NumberStream(Stream.iterate(0, lambda i: i + 1))</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.odds"><code class="name flex">
+<span>def <span class="ident">odds</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of odds number from 0 to infinity</p>
+<p>:return: the infinite stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def odds():
+    &#39;&#39;&#39;
+    Returns an infinite stream of odds number from 0 to infinity
+
+    :return: the infinite stream
+    &#39;&#39;&#39;
+    return NumberStream(Stream.iterate(1, lambda i: i + 2))</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.pi"><code class="name flex">
+<span>def <span class="ident">pi</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream with the digits of PI.</p>
+<p>:return: the PI's digits stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def pi():
+    &#39;&#39;&#39;
+    Returns a stream with the digits of PI.
+
+    :return: the PI&#39;s digits stream
+    &#39;&#39;&#39;
+    def pi_digits():
+        &#34;Generate n digits of Pi.&#34;
+        k, a, b, a1, b1 = 2, 4, 1, 12, 4
+        while True:
+            p, q, k = k * k, 2 * k + 1, k + 1
+            a, b, a1, b1 = a1, b1, p * a + q * a1, p * b + q * b1
+            d, d1 = a / b, a1 / b1
+            while d == d1:
+                yield int(d)
+                a, a1 = 10 * (a % b), 10 * (a1 % b1)
+                d, d1 = a / b, a1 / b1
+
+    return NumberStream(Stream(pi_digits()))</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.primes"><code class="name flex">
+<span>def <span class="ident">primes</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of primes number from 2 to infinity</p>
+<p>:return: the infinite stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def primes():
+    &#39;&#39;&#39;
+    Returns an infinite stream of primes number from 2 to infinity
+
+    :return: the infinite stream
+    &#39;&#39;&#39;
+    def prime_generator():
+        yield 2
+        primes = [2]
+        actual = 1
+        while True:
+            actual += 2
+            for prime in primes:
+                if actual % prime == 0:
+                    break
+            else:
+                primes.append(actual)
+                yield actual
+
+    return NumberStream(prime_generator())</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.randint"><code class="name flex">
+<span>def <span class="ident">randint</span></span>(<span>lower, upper)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of random integer in range [a, b], including both end points.</p>
 <p>:param int lower: min value for random numbers
 :param int upper: max value for random numbers
-:return: the infinite random stream</p>
-</div>
+:return: the infinite random stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def randint(lower, upper):
+    &#39;&#39;&#39;
+    Returns an infinite stream of random integer in range [a, b], including both end points.
 
-
-                            </div>
-                            <div id="NumberStream.random" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.random">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">random</span><span class="signature">()</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">random</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite stream of random numbers in range [0, 1], including both end points.</span>
-
-<span class="sd">        :param int lower: min value for random numbers</span>
-<span class="sd">        :param int upper: max value for random numbers</span>
-<span class="sd">        :return: the infinite random stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="n">random</span><span class="o">.</span><span class="n">random</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an infinite stream of random numbers in range [0, 1], including both end points.</p>
-
+    :param int lower: min value for random numbers
+    :param int upper: max value for random numbers
+    :return: the infinite random stream
+    &#39;&#39;&#39;
+    return NumberStream(Stream.generate(lambda: random.randint(lower, upper)))</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.random"><code class="name flex">
+<span>def <span class="ident">random</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite stream of random numbers in range [0, 1], including both end points.</p>
 <p>:param int lower: min value for random numbers
 :param int upper: max value for random numbers
-:return: the infinite random stream</p>
-</div>
+:return: the infinite random stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def random():
+    &#39;&#39;&#39;
+    Returns an infinite stream of random numbers in range [0, 1], including both end points.
 
-
-                            </div>
-                            <div id="NumberStream.range" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.range">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">range</span><span class="signature">(start, end, step=1)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">range</span><span class="p">(</span><span class="n">start</span><span class="p">,</span> <span class="n">end</span><span class="p">,</span> <span class="n">step</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream of numbers from start to end with specified step.</span>
-
-<span class="sd">        :param int start: the start value</span>
-<span class="sd">        :param int end: the max value</span>
-<span class="sd">        :param int step: the step</span>
-<span class="sd">        :return: the new stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="n">start</span><span class="p">,</span> <span class="k">lambda</span> <span class="n">i</span><span class="p">:</span> <span class="n">i</span> <span class="o">+</span> <span class="n">step</span><span class="p">)</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">end</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream of numbers from start to end with specified step.</p>
-
+    :param int lower: min value for random numbers
+    :param int upper: max value for random numbers
+    :return: the infinite random stream
+    &#39;&#39;&#39;
+    return NumberStream(Stream.generate(random.random))</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.range"><code class="name flex">
+<span>def <span class="ident">range</span></span>(<span>start, end, step=1)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream of numbers from start to end with specified step.</p>
 <p>:param int start: the start value
 :param int end: the max value
 :param int step: the step
-:return: the new stream</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.pi" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.pi">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">pi</span><span class="signature">()</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">pi</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream with the digits of PI.</span>
-
-<span class="sd">        :return: the PI&#39;s digits stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">def</span> <span class="nf">pi_digits</span><span class="p">():</span>
-            <span class="s2">&quot;Generate n digits of Pi.&quot;</span>
-            <span class="n">k</span><span class="p">,</span> <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span> <span class="o">=</span> <span class="mi">2</span><span class="p">,</span> <span class="mi">4</span><span class="p">,</span> <span class="mi">1</span><span class="p">,</span> <span class="mi">12</span><span class="p">,</span> <span class="mi">4</span>
-            <span class="k">while</span> <span class="kc">True</span><span class="p">:</span>
-                <span class="n">p</span><span class="p">,</span> <span class="n">q</span><span class="p">,</span> <span class="n">k</span> <span class="o">=</span> <span class="n">k</span> <span class="o">*</span> <span class="n">k</span><span class="p">,</span> <span class="mi">2</span> <span class="o">*</span> <span class="n">k</span> <span class="o">+</span> <span class="mi">1</span><span class="p">,</span> <span class="n">k</span> <span class="o">+</span> <span class="mi">1</span>
-                <span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span> <span class="o">=</span> <span class="n">a1</span><span class="p">,</span> <span class="n">b1</span><span class="p">,</span> <span class="n">p</span> <span class="o">*</span> <span class="n">a</span> <span class="o">+</span> <span class="n">q</span> <span class="o">*</span> <span class="n">a1</span><span class="p">,</span> <span class="n">p</span> <span class="o">*</span> <span class="n">b</span> <span class="o">+</span> <span class="n">q</span> <span class="o">*</span> <span class="n">b1</span>
-                <span class="n">d</span><span class="p">,</span> <span class="n">d1</span> <span class="o">=</span> <span class="n">a</span> <span class="o">/</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span> <span class="o">/</span> <span class="n">b1</span>
-                <span class="k">while</span> <span class="n">d</span> <span class="o">==</span> <span class="n">d1</span><span class="p">:</span>
-                    <span class="k">yield</span> <span class="nb">int</span><span class="p">(</span><span class="n">d</span><span class="p">)</span>
-                    <span class="n">a</span><span class="p">,</span> <span class="n">a1</span> <span class="o">=</span> <span class="mi">10</span> <span class="o">*</span> <span class="p">(</span><span class="n">a</span> <span class="o">%</span> <span class="n">b</span><span class="p">),</span> <span class="mi">10</span> <span class="o">*</span> <span class="p">(</span><span class="n">a1</span> <span class="o">%</span> <span class="n">b1</span><span class="p">)</span>
-                    <span class="n">d</span><span class="p">,</span> <span class="n">d1</span> <span class="o">=</span> <span class="n">a</span> <span class="o">/</span> <span class="n">b</span><span class="p">,</span> <span class="n">a1</span> <span class="o">/</span> <span class="n">b1</span>
-
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="n">Stream</span><span class="p">(</span><span class="n">pi_digits</span><span class="p">()))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream with the digits of PI.</p>
-
-<p>:return: the PI's digits stream</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.average" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.average">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">average</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">average</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Get the average value of the element of the stream.</span>
-
-<span class="sd">        :return: the average value</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">_sum</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="n">_count</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="p">:</span>
-            <span class="n">_sum</span> <span class="o">+=</span> <span class="n">elem</span>
-            <span class="n">_count</span> <span class="o">+=</span> <span class="mi">1</span>
-        <span class="k">return</span> <span class="n">_sum</span> <span class="o">/</span> <span class="n">_count</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Get the average value of the element of the stream.</p>
-
-<p>:return: the average value</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.takeWhileSmallerThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.takeWhileSmallerThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">takeWhileSmallerThan</span><span class="signature">(self, maximum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">takeWhileSmallerThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;</span> <span class="n">maximum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.takeWhileSmallerOrEqualThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.takeWhileSmallerOrEqualThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">takeWhileSmallerOrEqualThan</span><span class="signature">(self, maximum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">takeWhileSmallerOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">maximum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.takeWhileGreaterThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.takeWhileGreaterThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">takeWhileGreaterThan</span><span class="signature">(self, minimum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">takeWhileGreaterThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;</span> <span class="n">minimum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.takeWhileGreaterOrEqualThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.takeWhileGreaterOrEqualThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">takeWhileGreaterOrEqualThan</span><span class="signature">(self, minimum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">takeWhileGreaterOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;=</span> <span class="n">minimum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.smallerThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.smallerThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">smallerThan</span><span class="signature">(self, maximum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">smallerThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are smaller than the specified value</span>
-
-<span class="sd">        :param int maximum: the maximum value [exclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;</span> <span class="n">maximum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream that are smaller than the specified value</p>
-
-<p>:param int maximum: the maximum value [exclusive]
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.smallerOrEqualThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.smallerOrEqualThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">smallerOrEqualThan</span><span class="signature">(self, maximum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">smallerOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">maximum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value</span>
-
-<span class="sd">        :param int maximum: the maximum value [inclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&lt;=</span> <span class="n">maximum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value</p>
-
-<p>:param int maximum: the maximum value [inclusive]
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.greaterThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.greaterThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">greaterThan</span><span class="signature">(self, minimum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">greaterThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are greater than the specified value</span>
-
-<span class="sd">        :param int minimum: the minimum value [exclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;</span> <span class="n">minimum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream that are greater than the specified value</p>
-
-<p>:param int minimum: the minimum value [exclusive]
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.greaterOrEqualThan" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.greaterOrEqualThan">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">greaterOrEqualThan</span><span class="signature">(self, minimum)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">greaterOrEqualThan</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">minimum</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are greater than the specified value</span>
-
-<span class="sd">        :param int minimum: the minimum value [inclusive]</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">&gt;=</span> <span class="n">minimum</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream that are greater than the specified value</p>
-
+:return: the new stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def range(start, end, step=1):
+    &#39;&#39;&#39;
+    Returns a stream of numbers from start to end with specified step.
+
+    :param int start: the start value
+    :param int end: the max value
+    :param int step: the step
+    :return: the new stream
+    &#39;&#39;&#39;
+    return NumberStream(Stream.iterate(start, lambda i: i + step).takeWhile(lambda x: x &lt;= end))</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="stream.numbers.NumberStream.average"><code class="name flex">
+<span>def <span class="ident">average</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Get the average value of the element of the stream.</p>
+<p>:return: the average value</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def average(self):
+    &#39;&#39;&#39;
+    Get the average value of the element of the stream.
+
+    :return: the average value
+    &#39;&#39;&#39;
+    _sum = 0
+    _count = 0
+    for elem in self:
+        _sum += elem
+        _count += 1
+    return _sum / _count</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.cos"><code class="name flex">
+<span>def <span class="ident">cos</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the cos of the element of this stream</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def cos(self):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the cos of the element of this stream
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.map(math.cos)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.cube"><code class="name flex">
+<span>def <span class="ident">cube</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the cube of the element of this stream</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def cube(self):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the cube of the element of this stream
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.pow(3)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.greaterOrEqualThan"><code class="name flex">
+<span>def <span class="ident">greaterOrEqualThan</span></span>(<span>self, minimum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream that are greater than the specified value</p>
 <p>:param int minimum: the minimum value [inclusive]
-:return: self</p>
-</div>
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def greaterOrEqualThan(self, minimum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream that are greater than the specified value
 
+    :param int minimum: the minimum value [inclusive]
+    :return: self
+    &#39;&#39;&#39;
+    return self.filter(lambda x: x &gt;= minimum)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.greaterThan"><code class="name flex">
+<span>def <span class="ident">greaterThan</span></span>(<span>self, minimum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream that are greater than the specified value</p>
+<p>:param int minimum: the minimum value [exclusive]
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def greaterThan(self, minimum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream that are greater than the specified value
 
-                            </div>
-                            <div id="NumberStream.multipleOf" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.multipleOf">#&nbsp;&nbsp</a>
+    :param int minimum: the minimum value [exclusive]
+    :return: self
+    &#39;&#39;&#39;
+    return self.filter(lambda x: x &gt; minimum)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.log"><code class="name flex">
+<span>def <span class="ident">log</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the log of the element of this stream</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def log(self):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the log of the element of this stream
 
-        
-            <span class="def">def</span>
-            <span class="name">multipleOf</span><span class="signature">(self, number)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">multipleOf</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">number</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream that are multiple of the specified value</span>
-
-<span class="sd">        :param int number: the value</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">%</span> <span class="n">number</span> <span class="o">==</span> <span class="mi">0</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream that are multiple of the specified value</p>
-
+    :return: self
+    &#39;&#39;&#39;
+    return self.map(math.log)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.multipleOf"><code class="name flex">
+<span>def <span class="ident">multipleOf</span></span>(<span>self, number)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream that are multiple of the specified value</p>
 <p>:param int number: the value
-:return: self</p>
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def multipleOf(self, number):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream that are multiple of the specified value
+
+    :param int number: the value
+    :return: self
+    &#39;&#39;&#39;
+    return self.filter(lambda x: x % number == 0)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.pow"><code class="name flex">
+<span>def <span class="ident">pow</span></span>(<span>self, power)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the pow to the specified value of the element of this stream</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def pow(self, power):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the pow to the specified value of the element of this stream
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.map(lambda x: x ** power)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.sin"><code class="name flex">
+<span>def <span class="ident">sin</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the sin of the element of this stream</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sin(self):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the sin of the element of this stream
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.map(math.sin)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.smallerOrEqualThan"><code class="name flex">
+<span>def <span class="ident">smallerOrEqualThan</span></span>(<span>self, maximum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value</p>
+<p>:param int maximum: the maximum value [inclusive]
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def smallerOrEqualThan(self, maximum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream that are smaller or equal than the specified value
+
+    :param int maximum: the maximum value [inclusive]
+    :return: self
+    &#39;&#39;&#39;
+    return self.filter(lambda x: x &lt;= maximum)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.smallerThan"><code class="name flex">
+<span>def <span class="ident">smallerThan</span></span>(<span>self, maximum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream that are smaller than the specified value</p>
+<p>:param int maximum: the maximum value [exclusive]
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def smallerThan(self, maximum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream that are smaller than the specified value
+
+    :param int maximum: the maximum value [exclusive]
+    :return: self
+    &#39;&#39;&#39;
+    return self.filter(lambda x: x &lt; maximum)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.sqrt"><code class="name flex">
+<span>def <span class="ident">sqrt</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the square root of the element of this stream</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sqrt(self):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the square root of the element of this stream
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.map(math.sqrt)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.square"><code class="name flex">
+<span>def <span class="ident">square</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the square of the element of this stream</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def square(self):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the square of the element of this stream
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.pow(2)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.takeWhileGreaterOrEqualThan"><code class="name flex">
+<span>def <span class="ident">takeWhileGreaterOrEqualThan</span></span>(<span>self, minimum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def takeWhileGreaterOrEqualThan(self, minimum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the longest prefix of elements taken from this stream that is greater or equal than the specified value
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.takeWhile(lambda x: x &gt;= minimum)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.takeWhileGreaterThan"><code class="name flex">
+<span>def <span class="ident">takeWhileGreaterThan</span></span>(<span>self, minimum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def takeWhileGreaterThan(self, minimum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the longest prefix of elements taken from this stream that is greater than the specified value
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.takeWhile(lambda x: x &gt; minimum)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.takeWhileSmallerOrEqualThan"><code class="name flex">
+<span>def <span class="ident">takeWhileSmallerOrEqualThan</span></span>(<span>self, maximum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def takeWhileSmallerOrEqualThan(self, maximum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller or equal than the specified value
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.takeWhile(lambda x: x &lt;= maximum)</code></pre>
+</details>
+</dd>
+<dt id="stream.numbers.NumberStream.takeWhileSmallerThan"><code class="name flex">
+<span>def <span class="ident">takeWhileSmallerThan</span></span>(<span>self, maximum)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def takeWhileSmallerThan(self, maximum):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the longest prefix of elements taken from this stream that is smaller than the specified value
+
+    :return: self
+    &#39;&#39;&#39;
+    return self.takeWhile(lambda x: x &lt; maximum)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Inherited members</h3>
+<ul class="hlist">
+<li><code><b><a title="stream.stream.Stream" href="stream.html#stream.stream.Stream">Stream</a></b></code>:
+<ul class="hlist">
+<li><code><a title="stream.stream.Stream.allMatch" href="stream.html#stream.stream.Stream.allMatch">allMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.anyMatch" href="stream.html#stream.stream.Stream.anyMatch">anyMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.concat" href="stream.html#stream.stream.Stream.concat">concat</a></code></li>
+<li><code><a title="stream.stream.Stream.constant" href="stream.html#stream.stream.Stream.constant">constant</a></code></li>
+<li><code><a title="stream.stream.Stream.count" href="stream.html#stream.stream.Stream.count">count</a></code></li>
+<li><code><a title="stream.stream.Stream.distinct" href="stream.html#stream.stream.Stream.distinct">distinct</a></code></li>
+<li><code><a title="stream.stream.Stream.dropWhile" href="stream.html#stream.stream.Stream.dropWhile">dropWhile</a></code></li>
+<li><code><a title="stream.stream.Stream.empty" href="stream.html#stream.stream.Stream.empty">empty</a></code></li>
+<li><code><a title="stream.stream.Stream.filter" href="stream.html#stream.stream.Stream.filter">filter</a></code></li>
+<li><code><a title="stream.stream.Stream.findAny" href="stream.html#stream.stream.Stream.findAny">findAny</a></code></li>
+<li><code><a title="stream.stream.Stream.findFirst" href="stream.html#stream.stream.Stream.findFirst">findFirst</a></code></li>
+<li><code><a title="stream.stream.Stream.flatMap" href="stream.html#stream.stream.Stream.flatMap">flatMap</a></code></li>
+<li><code><a title="stream.stream.Stream.forEach" href="stream.html#stream.stream.Stream.forEach">forEach</a></code></li>
+<li><code><a title="stream.stream.Stream.generate" href="stream.html#stream.stream.Stream.generate">generate</a></code></li>
+<li><code><a title="stream.stream.Stream.iterate" href="stream.html#stream.stream.Stream.iterate">iterate</a></code></li>
+<li><code><a title="stream.stream.Stream.limit" href="stream.html#stream.stream.Stream.limit">limit</a></code></li>
+<li><code><a title="stream.stream.Stream.map" href="stream.html#stream.stream.Stream.map">map</a></code></li>
+<li><code><a title="stream.stream.Stream.max" href="stream.html#stream.stream.Stream.max">max</a></code></li>
+<li><code><a title="stream.stream.Stream.min" href="stream.html#stream.stream.Stream.min">min</a></code></li>
+<li><code><a title="stream.stream.Stream.noneMatch" href="stream.html#stream.stream.Stream.noneMatch">noneMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.of" href="stream.html#stream.stream.Stream.of">of</a></code></li>
+<li><code><a title="stream.stream.Stream.ofNullable" href="stream.html#stream.stream.Stream.ofNullable">ofNullable</a></code></li>
+<li><code><a title="stream.stream.Stream.peek" href="stream.html#stream.stream.Stream.peek">peek</a></code></li>
+<li><code><a title="stream.stream.Stream.reduce" href="stream.html#stream.stream.Stream.reduce">reduce</a></code></li>
+<li><code><a title="stream.stream.Stream.skip" href="stream.html#stream.stream.Stream.skip">skip</a></code></li>
+<li><code><a title="stream.stream.Stream.sorted" href="stream.html#stream.stream.Stream.sorted">sorted</a></code></li>
+<li><code><a title="stream.stream.Stream.sum" href="stream.html#stream.stream.Stream.sum">sum</a></code></li>
+<li><code><a title="stream.stream.Stream.takeWhile" href="stream.html#stream.stream.Stream.takeWhile">takeWhile</a></code></li>
+<li><code><a title="stream.stream.Stream.toList" href="stream.html#stream.stream.Stream.toList">toList</a></code></li>
+<li><code><a title="stream.stream.Stream.toSet" href="stream.html#stream.stream.Stream.toSet">toSet</a></code></li>
+</ul>
+</li>
+</ul>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
 </div>
-
-
-                            </div>
-                            <div id="NumberStream.square" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.square">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">square</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">square</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the square of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pow</span><span class="p">(</span><span class="mi">2</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the square of the element of this stream</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.cube" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.cube">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">cube</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">cube</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the cube of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">pow</span><span class="p">(</span><span class="mi">3</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the cube of the element of this stream</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.pow" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.pow">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">pow</span><span class="signature">(self, power)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">pow</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">power</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the pow to the specified value of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">:</span> <span class="n">x</span> <span class="o">**</span> <span class="n">power</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the pow to the specified value of the element of this stream</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.sqrt" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.sqrt">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">sqrt</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">sqrt</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the square root of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">sqrt</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the square root of the element of this stream</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.log" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.log">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">log</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">log</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the log of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">log</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the log of the element of this stream</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.sin" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.sin">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">sin</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">sin</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the sin of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">sin</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the sin of the element of this stream</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="NumberStream.cos" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#NumberStream.cos">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">cos</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">cos</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the cos of the element of this stream</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="n">math</span><span class="o">.</span><span class="n">cos</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the cos of the element of this stream</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div class="inherited">
-                                <h5>Inherited Members</h5>
-                                <dl>
-                                    <div><dt><a href="stream.html#Stream">stream.stream.Stream</a></dt>
-                                <dd id="NumberStream.empty" class="function"><a href="stream.html#Stream.empty">empty</a></dd>
-                <dd id="NumberStream.of" class="function"><a href="stream.html#Stream.of">of</a></dd>
-                <dd id="NumberStream.ofNullable" class="function"><a href="stream.html#Stream.ofNullable">ofNullable</a></dd>
-                <dd id="NumberStream.iterate" class="function"><a href="stream.html#Stream.iterate">iterate</a></dd>
-                <dd id="NumberStream.generate" class="function"><a href="stream.html#Stream.generate">generate</a></dd>
-                <dd id="NumberStream.concat" class="function"><a href="stream.html#Stream.concat">concat</a></dd>
-                <dd id="NumberStream.constant" class="function"><a href="stream.html#Stream.constant">constant</a></dd>
-                <dd id="NumberStream.filter" class="function"><a href="stream.html#Stream.filter">filter</a></dd>
-                <dd id="NumberStream.map" class="function"><a href="stream.html#Stream.map">map</a></dd>
-                <dd id="NumberStream.flatMap" class="function"><a href="stream.html#Stream.flatMap">flatMap</a></dd>
-                <dd id="NumberStream.distinct" class="function"><a href="stream.html#Stream.distinct">distinct</a></dd>
-                <dd id="NumberStream.limit" class="function"><a href="stream.html#Stream.limit">limit</a></dd>
-                <dd id="NumberStream.skip" class="function"><a href="stream.html#Stream.skip">skip</a></dd>
-                <dd id="NumberStream.takeWhile" class="function"><a href="stream.html#Stream.takeWhile">takeWhile</a></dd>
-                <dd id="NumberStream.dropWhile" class="function"><a href="stream.html#Stream.dropWhile">dropWhile</a></dd>
-                <dd id="NumberStream.sorted" class="function"><a href="stream.html#Stream.sorted">sorted</a></dd>
-                <dd id="NumberStream.peek" class="function"><a href="stream.html#Stream.peek">peek</a></dd>
-                <dd id="NumberStream.forEach" class="function"><a href="stream.html#Stream.forEach">forEach</a></dd>
-                <dd id="NumberStream.anyMatch" class="function"><a href="stream.html#Stream.anyMatch">anyMatch</a></dd>
-                <dd id="NumberStream.allMatch" class="function"><a href="stream.html#Stream.allMatch">allMatch</a></dd>
-                <dd id="NumberStream.noneMatch" class="function"><a href="stream.html#Stream.noneMatch">noneMatch</a></dd>
-                <dd id="NumberStream.findFirst" class="function"><a href="stream.html#Stream.findFirst">findFirst</a></dd>
-                <dd id="NumberStream.findAny" class="function"><a href="stream.html#Stream.findAny">findAny</a></dd>
-                <dd id="NumberStream.reduce" class="function"><a href="stream.html#Stream.reduce">reduce</a></dd>
-                <dd id="NumberStream.min" class="function"><a href="stream.html#Stream.min">min</a></dd>
-                <dd id="NumberStream.max" class="function"><a href="stream.html#Stream.max">max</a></dd>
-                <dd id="NumberStream.sum" class="function"><a href="stream.html#Stream.sum">sum</a></dd>
-                <dd id="NumberStream.count" class="function"><a href="stream.html#Stream.count">count</a></dd>
-                <dd id="NumberStream.toList" class="function"><a href="stream.html#Stream.toList">toList</a></dd>
-                <dd id="NumberStream.toSet" class="function"><a href="stream.html#Stream.toSet">toSet</a></dd>
-                <dd id="NumberStream.toNumberStream" class="function"><a href="stream.html#Stream.toNumberStream">toNumberStream</a></dd>
-                <dd id="NumberStream.toBooleanStream" class="function"><a href="stream.html#Stream.toBooleanStream">toBooleanStream</a></dd>
-
-            </div>
-                                </dl>
-                            </div>
-                </section>
-    </main>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="stream" href="index.html">stream</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="stream.numbers.NumberStream" href="#stream.numbers.NumberStream">NumberStream</a></code></h4>
+<ul class="">
+<li><code><a title="stream.numbers.NumberStream.average" href="#stream.numbers.NumberStream.average">average</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.cos" href="#stream.numbers.NumberStream.cos">cos</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.cube" href="#stream.numbers.NumberStream.cube">cube</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.evens" href="#stream.numbers.NumberStream.evens">evens</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.greaterOrEqualThan" href="#stream.numbers.NumberStream.greaterOrEqualThan">greaterOrEqualThan</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.greaterThan" href="#stream.numbers.NumberStream.greaterThan">greaterThan</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.integers" href="#stream.numbers.NumberStream.integers">integers</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.log" href="#stream.numbers.NumberStream.log">log</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.multipleOf" href="#stream.numbers.NumberStream.multipleOf">multipleOf</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.odds" href="#stream.numbers.NumberStream.odds">odds</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.pi" href="#stream.numbers.NumberStream.pi">pi</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.pow" href="#stream.numbers.NumberStream.pow">pow</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.primes" href="#stream.numbers.NumberStream.primes">primes</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.randint" href="#stream.numbers.NumberStream.randint">randint</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.random" href="#stream.numbers.NumberStream.random">random</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.range" href="#stream.numbers.NumberStream.range">range</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.sin" href="#stream.numbers.NumberStream.sin">sin</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.smallerOrEqualThan" href="#stream.numbers.NumberStream.smallerOrEqualThan">smallerOrEqualThan</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.smallerThan" href="#stream.numbers.NumberStream.smallerThan">smallerThan</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.sqrt" href="#stream.numbers.NumberStream.sqrt">sqrt</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.square" href="#stream.numbers.NumberStream.square">square</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.takeWhileGreaterOrEqualThan" href="#stream.numbers.NumberStream.takeWhileGreaterOrEqualThan">takeWhileGreaterOrEqualThan</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.takeWhileGreaterThan" href="#stream.numbers.NumberStream.takeWhileGreaterThan">takeWhileGreaterThan</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.takeWhileSmallerOrEqualThan" href="#stream.numbers.NumberStream.takeWhileSmallerOrEqualThan">takeWhileSmallerOrEqualThan</a></code></li>
+<li><code><a title="stream.numbers.NumberStream.takeWhileSmallerThan" href="#stream.numbers.NumberStream.takeWhileSmallerThan">takeWhileSmallerThan</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
 </body>
 </html>

--- a/doc/stream/stream.html
+++ b/doc/stream/stream.html
@@ -1,1929 +1,1580 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="generator" content="pdoc 6.3.2" />
-    <title>stream.stream API documentation</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
-
-
-<style type="text/css">/*! * Bootstrap Reboot v5.0.0-beta1 (https://getbootstrap.com/) * Copyright 2011-2020 The Bootstrap Authors * Copyright 2011-2020 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}[tabindex="-1"]:focus:not(:focus-visible){outline:0!important}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{text-decoration:underline;-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus{outline:dotted 1px;outline:-webkit-focus-ring-color auto 5px}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
-<style type="text/css">/*! pygments syntax highlighting */pre{line-height:125%;}td.linenos pre{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}span.linenos{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}td.linenos pre.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}span.linenos.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}.pdoc .hll{background-color:#ffffcc}.pdoc{background:#f8f8f8;}.pdoc .c{color:#408080; font-style:italic}.pdoc .err{border:1px solid #FF0000}.pdoc .k{color:#008000; font-weight:bold}.pdoc .o{color:#666666}.pdoc .ch{color:#408080; font-style:italic}.pdoc .cm{color:#408080; font-style:italic}.pdoc .cp{color:#BC7A00}.pdoc .cpf{color:#408080; font-style:italic}.pdoc .c1{color:#408080; font-style:italic}.pdoc .cs{color:#408080; font-style:italic}.pdoc .gd{color:#A00000}.pdoc .ge{font-style:italic}.pdoc .gr{color:#FF0000}.pdoc .gh{color:#000080; font-weight:bold}.pdoc .gi{color:#00A000}.pdoc .go{color:#888888}.pdoc .gp{color:#000080; font-weight:bold}.pdoc .gs{font-weight:bold}.pdoc .gu{color:#800080; font-weight:bold}.pdoc .gt{color:#0044DD}.pdoc .kc{color:#008000; font-weight:bold}.pdoc .kd{color:#008000; font-weight:bold}.pdoc .kn{color:#008000; font-weight:bold}.pdoc .kp{color:#008000}.pdoc .kr{color:#008000; font-weight:bold}.pdoc .kt{color:#B00040}.pdoc .m{color:#666666}.pdoc .s{color:#BA2121}.pdoc .na{color:#7D9029}.pdoc .nb{color:#008000}.pdoc .nc{color:#0000FF; font-weight:bold}.pdoc .no{color:#880000}.pdoc .nd{color:#AA22FF}.pdoc .ni{color:#999999; font-weight:bold}.pdoc .ne{color:#D2413A; font-weight:bold}.pdoc .nf{color:#0000FF}.pdoc .nl{color:#A0A000}.pdoc .nn{color:#0000FF; font-weight:bold}.pdoc .nt{color:#008000; font-weight:bold}.pdoc .nv{color:#19177C}.pdoc .ow{color:#AA22FF; font-weight:bold}.pdoc .w{color:#bbbbbb}.pdoc .mb{color:#666666}.pdoc .mf{color:#666666}.pdoc .mh{color:#666666}.pdoc .mi{color:#666666}.pdoc .mo{color:#666666}.pdoc .sa{color:#BA2121}.pdoc .sb{color:#BA2121}.pdoc .sc{color:#BA2121}.pdoc .dl{color:#BA2121}.pdoc .sd{color:#BA2121; font-style:italic}.pdoc .s2{color:#BA2121}.pdoc .se{color:#BB6622; font-weight:bold}.pdoc .sh{color:#BA2121}.pdoc .si{color:#BB6688; font-weight:bold}.pdoc .sx{color:#008000}.pdoc .sr{color:#BB6688}.pdoc .s1{color:#BA2121}.pdoc .ss{color:#19177C}.pdoc .bp{color:#008000}.pdoc .fm{color:#0000FF}.pdoc .vc{color:#19177C}.pdoc .vg{color:#19177C}.pdoc .vi{color:#19177C}.pdoc .vm{color:#19177C}.pdoc .il{color:#666666}</style>
-<style type="text/css">/*! pdoc */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f7f7f7;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}body{background-color:var(--pdoc-background);}html, body{width:100%;height:100%;}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main{padding:2rem 3vw;}.git-button{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}#navtoggle{display:none;}}#togglestate{display:none;}nav.pdoc{--pad:1.75rem;--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc li{display:block;margin:0;padding:.2rem 0 .2rem var(--indent);transition:all 100ms;}nav.pdoc > div > ul > li{padding-left:0;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}html, main{scroll-behavior:smooth;}.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3, .pdoc h4{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{background-color:var(--code);border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.pdoc details{--shift:-40px;text-align:right;margin-top:var(--shift);margin-bottom:calc(0px - var(--shift));clear:both;filter:opacity(1);}.pdoc details:not([open]){height:0;overflow:visible;}.pdoc details > summary{font-size:.75rem;cursor:pointer;color:var(--muted);border-width:0;padding:0 .7em;display:inline-block;display:inline list-item;user-select:none;}.pdoc details > summary:focus{outline:0;}.pdoc details > div{margin-top:calc(0px - var(--shift) / 2);text-align:left;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc > section:first-of-type > .docstring{margin-bottom:3rem;}.pdoc .docstring pre{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc .headerlink{position:absolute;width:0;margin-left:-1.5rem;line-height:1.4rem;font-size:1.5rem;font-weight:normal;transition:all 100ms ease-in-out;opacity:0;}.pdoc .attr > .headerlink{margin-left:-2.5rem;}.pdoc *:hover > .headerlink,.pdoc *:target > .attr > .headerlink{opacity:1;}.pdoc .attr{color:var(--text);margin:1rem 0 .5rem;padding:.4rem 5rem .4rem 1rem;background-color:var(--accent);}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{white-space:pre-wrap;}.pdoc .annotation{color:var(--annotation);}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}</style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>stream.stream API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
-<body>        <nav class="pdoc">
-            <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
-            <input id="togglestate" type="checkbox">
-            <div>
-                        <a class="pdoc-button module-list-button" href="../stream.html">
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-in-left" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M10 3.5a.5.5 0 0 0-.5-.5h-8a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-2a.5.5 0 0 1 1 0v2A1.5 1.5 0 0 1 9.5 14h-8A1.5 1.5 0 0 1 0 12.5v-9A1.5 1.5 0 0 1 1.5 2h8A1.5 1.5 0 0 1 11 3.5v2a.5.5 0 0 1-1 0v-2z"/>
-  <path fill-rule="evenodd" d="M4.146 8.354a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H14.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3z"/>
-</svg>                            &nbsp;stream</a>
-
-
-
-
-                    <h2>API Documentation</h2>
-                        <ul class="memberlist">
-            <li>
-                    <a class="class" href="#Stream">Stream</a>
-                            <ul class="memberlist">
-                        <li>
-                                <a class="function" href="#Stream.__init__">Stream</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.empty">empty</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.of">of</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.ofNullable">ofNullable</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.iterate">iterate</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.generate">generate</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.concat">concat</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.constant">constant</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.filter">filter</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.map">map</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.flatMap">flatMap</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.distinct">distinct</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.limit">limit</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.skip">skip</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.takeWhile">takeWhile</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.dropWhile">dropWhile</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.sorted">sorted</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.peek">peek</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.forEach">forEach</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.anyMatch">anyMatch</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.allMatch">allMatch</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.noneMatch">noneMatch</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.findFirst">findFirst</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.findAny">findAny</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.reduce">reduce</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.min">min</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.max">max</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.sum">sum</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.count">count</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.toList">toList</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.toSet">toSet</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.toNumberStream">toNumberStream</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Stream.toBooleanStream">toBooleanStream</a>
-                        </li>
-                </ul>
-
-            </li>
-    </ul>
-
-
-                    <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev">
-                        built with <span class="visually-hidden">pdoc</span><img
-                            alt="pdoc logo"
-                            src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
-                    </a>
-            </div>
-        </nav>
-    <main class="pdoc">
-            <section>
-                    <h1 class="modulename">
-<a href="./../stream.html">stream</a>.stream    </h1>
-
-                
-                        <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="kn">from</span> <span class="nn">functools</span> <span class="kn">import</span> <span class="n">cmp_to_key</span>
-<span class="kn">import</span> <span class="nn">random</span>
-
-<span class="kn">from</span> <span class="nn">.util.iterators</span> <span class="kn">import</span> <span class="n">IteratorUtils</span>
-<span class="kn">from</span> <span class="nn">.util.optional</span> <span class="kn">import</span> <span class="n">Optional</span>
-
-
-<span class="k">class</span> <span class="nc">Stream</span><span class="p">():</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A sequence of elements supporting sequential operations.</span>
-
-<span class="sd">    The following example illustrates an aggregate operation using</span>
-<span class="sd">    Stream:</span>
-
-<span class="sd">        result = Stream(elements)</span>
-<span class="sd">                        .filter(lambda w: w.getColor() == RED)</span>
-<span class="sd">                        .map(lambda w: w.getWeight())</span>
-<span class="sd">                        .sum()</span>
-
-<span class="sd">    A stream pipeline, like the elements example above, can be viewed as a query on the stream source.</span>
-
-<span class="sd">    A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, &quot;forked&quot; streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Static Methods</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">empty</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an empty sequential Stream.</span>
-
-<span class="sd">        :return: an empty sequential stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">([])</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential Stream containing a single element.</span>
-
-<span class="sd">        :param T elem: the single element</span>
-<span class="sd">        :return: a singleton sequential stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="nb">iter</span><span class="p">([</span><span class="n">elem</span><span class="p">]))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="o">*</span><span class="n">elements</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential ordered stream whose elements are the specified values.</span>
-
-<span class="sd">        :param *T elements: the elements of the new stream</span>
-<span class="sd">        :return: the new stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="nb">iter</span><span class="p">(</span><span class="nb">list</span><span class="p">(</span><span class="n">elements</span><span class="p">)))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">ofNullable</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.</span>
-
-<span class="sd">        :param T elem: the single element</span>
-<span class="sd">        :return: a stream with a single element if the specified element is non-null, otherwise an empty stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="o">.</span><span class="n">of</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">if</span> <span class="n">elem</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Stream</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.</span>
-
-<span class="sd">        :param T seed: the initial element</span>
-<span class="sd">        :param UnaryOperator operator: a function to be applied to the previous element to produce a new element</span>
-<span class="sd">        :return: a new sequential Stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">generate</span><span class="p">(</span><span class="n">supplier</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.</span>
-
-<span class="sd">        :param Supplier supplier: the Supplier of generated elements</span>
-<span class="sd">        :return: a new infinite sequential unordered Stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="n">supplier</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">concat</span><span class="p">(</span><span class="o">*</span><span class="n">streams</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.</span>
-
-<span class="sd">        :param *Stream streams: the streams to concat</span>
-<span class="sd">        :return: the concatenation of the input streams</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">concat</span><span class="p">(</span><span class="o">*</span><span class="n">streams</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">constant</span><span class="p">(</span><span class="n">element</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Return an infinite sequential stream where each element is the passed element</span>
-
-<span class="sd">        :param T elem: the element</span>
-<span class="sd">        :return: the new stream made of @element</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">element</span><span class="p">)</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Normal Methods</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">iterable</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">iterable</span>
-
-    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</span>
-
-<span class="sd">        :param function predicate: predicate to apply to each element to determine if it should be included</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the results of applying the given function to the elements of this stream.</span>
-
-<span class="sd">        :param function mapper: function to apply to each element</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">flatMap</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">flatMapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)</span>
-
-<span class="sd">        :param function flatMapper: function to apply to each element which produces a stream of new values</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">flatMap</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">flatMapper</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">distinct</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the distinct elements of this stream.</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">distinct</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">limit</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.</span>
-
-<span class="sd">        :param int count:  the number of elements the stream should be limited to</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">limit</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">skip</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.</span>
-
-<span class="sd">        :param int count:  the number of leading elements to skip</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">skip</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">takeWhile</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.</span>
-
-<span class="sd">        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">dropWhile</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.</span>
-
-<span class="sd">        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">dropWhile</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    From here this method mustn&#39;t be called on infinite stream</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="nf">sorted</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="nb">iter</span><span class="p">(</span><span class="nb">sorted</span><span class="p">(</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">)))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="nb">iter</span><span class="p">(</span><span class="nb">sorted</span><span class="p">(</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">))</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">peek</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">consumer</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</span>
-
-<span class="sd">        :param Consumer consumer: action to perform on the elements as they are consumed from the stream</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">peek</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">consumer</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">forEach</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">function</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Performs an action for each element of this stream.</span>
-
-<span class="sd">        :param Function function: action to perform on the elements</span>
-<span class="sd">        :return: None</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="n">function</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">anyMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether any elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if any elements of the stream match the provided predicate, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">any</span><span class="p">([</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">])</span>
-
-    <span class="k">def</span> <span class="nf">allMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether all elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">all</span><span class="p">([</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">])</span>
-
-    <span class="k">def</span> <span class="nf">noneMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether no elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">anyMatch</span><span class="p">(</span><span class="n">predicate</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">findFirst</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the first element of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.</span>
-
-<span class="sd">        :return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">of</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">findAny</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.</span>
-
-<span class="sd">        :return: an Optional describing some element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">findFirst</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">reduce</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">accumulator</span><span class="p">,</span> <span class="n">identity</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.</span>
-
-<span class="sd">        :param T identity: the identity value for the accumulating function - if not specified it will be the first element of the stream</span>
-<span class="sd">        :param Accumulator accumulator: function for combining two values</span>
-<span class="sd">        :return: the result of reduction</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">result</span> <span class="o">=</span> <span class="n">identity</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">result</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">):</span>
-                <span class="n">result</span> <span class="o">=</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="n">result</span> <span class="o">=</span> <span class="n">accumulator</span><span class="p">(</span><span class="n">result</span><span class="p">,</span> <span class="n">elem</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="n">result</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">min</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used</span>
-<span class="sd">        :return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">elements</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">min</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">),</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">min</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="nf">max</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used</span>
-<span class="sd">        :return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">elements</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">max</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">)))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">max</span><span class="p">(</span><span class="n">elements</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="nf">sum</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the sum of all elements of this stream. This is a special case of a reduction.</span>
-
-<span class="sd">        :return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">reduce</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">:</span> <span class="n">x</span> <span class="o">+</span> <span class="n">y</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">count</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the count of elements in this stream. This is a special case of a reduction.</span>
-
-<span class="sd">        :return: the count of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">count</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="n">count</span> <span class="o">+=</span> <span class="mi">1</span>
-
-        <span class="k">return</span> <span class="n">count</span>
-
-    <span class="k">def</span> <span class="nf">toList</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a list with the elements in this stream.</span>
-
-<span class="sd">        :return: the list of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">toSet</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a set with the elements in this stream.</span>
-
-<span class="sd">        :return: the set of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">set</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">toNumberStream</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="kn">from</span> <span class="nn">.numbers</span> <span class="kn">import</span> <span class="n">NumberStream</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">toBooleanStream</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="kn">from</span> <span class="nn">.booleans</span> <span class="kn">import</span> <span class="n">BooleanStream</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__iter__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an iterator over the elements in this stream.</span>
-
-<span class="sd">        :return: the iterator over the elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">iter</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">value</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Check if this stream is equal to the specified stream</span>
-
-<span class="sd">        :return: True if the streams match, False otherwise</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">toSet</span><span class="p">()</span> <span class="o">==</span> <span class="n">value</span><span class="o">.</span><span class="n">toSet</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            </section>
-                <section id="Stream">
-                                <div class="attr class">
-        <a class="headerlink" href="#Stream">#&nbsp;&nbsp</a>
-
-        
-        <span class="def">class</span>
-        <span class="name">Stream</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Stream</span><span class="p">():</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    A sequence of elements supporting sequential operations.</span>
-
-<span class="sd">    The following example illustrates an aggregate operation using</span>
-<span class="sd">    Stream:</span>
-
-<span class="sd">        result = Stream(elements)</span>
-<span class="sd">                        .filter(lambda w: w.getColor() == RED)</span>
-<span class="sd">                        .map(lambda w: w.getWeight())</span>
-<span class="sd">                        .sum()</span>
-
-<span class="sd">    A stream pipeline, like the elements example above, can be viewed as a query on the stream source.</span>
-
-<span class="sd">    A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, &quot;forked&quot; streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Static Methods</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">empty</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an empty sequential Stream.</span>
-
-<span class="sd">        :return: an empty sequential stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">([])</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential Stream containing a single element.</span>
-
-<span class="sd">        :param T elem: the single element</span>
-<span class="sd">        :return: a singleton sequential stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="nb">iter</span><span class="p">([</span><span class="n">elem</span><span class="p">]))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="o">*</span><span class="n">elements</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential ordered stream whose elements are the specified values.</span>
-
-<span class="sd">        :param *T elements: the elements of the new stream</span>
-<span class="sd">        :return: the new stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="nb">iter</span><span class="p">(</span><span class="nb">list</span><span class="p">(</span><span class="n">elements</span><span class="p">)))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">ofNullable</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.</span>
-
-<span class="sd">        :param T elem: the single element</span>
-<span class="sd">        :return: a stream with a single element if the specified element is non-null, otherwise an empty stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="o">.</span><span class="n">of</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">if</span> <span class="n">elem</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Stream</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.</span>
-
-<span class="sd">        :param T seed: the initial element</span>
-<span class="sd">        :param UnaryOperator operator: a function to be applied to the previous element to produce a new element</span>
-<span class="sd">        :return: a new sequential Stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">generate</span><span class="p">(</span><span class="n">supplier</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.</span>
-
-<span class="sd">        :param Supplier supplier: the Supplier of generated elements</span>
-<span class="sd">        :return: a new infinite sequential unordered Stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="n">supplier</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">concat</span><span class="p">(</span><span class="o">*</span><span class="n">streams</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.</span>
-
-<span class="sd">        :param *Stream streams: the streams to concat</span>
-<span class="sd">        :return: the concatenation of the input streams</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">concat</span><span class="p">(</span><span class="o">*</span><span class="n">streams</span><span class="p">))</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">constant</span><span class="p">(</span><span class="n">element</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Return an infinite sequential stream where each element is the passed element</span>
-
-<span class="sd">        :param T elem: the element</span>
-<span class="sd">        :return: the new stream made of @element</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">element</span><span class="p">)</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Normal Methods</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">iterable</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">iterable</span>
-
-    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</span>
-
-<span class="sd">        :param function predicate: predicate to apply to each element to determine if it should be included</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the results of applying the given function to the elements of this stream.</span>
-
-<span class="sd">        :param function mapper: function to apply to each element</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">flatMap</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">flatMapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)</span>
-
-<span class="sd">        :param function flatMapper: function to apply to each element which produces a stream of new values</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">flatMap</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">flatMapper</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">distinct</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the distinct elements of this stream.</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">distinct</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">limit</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.</span>
-
-<span class="sd">        :param int count:  the number of elements the stream should be limited to</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">limit</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">skip</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.</span>
-
-<span class="sd">        :param int count:  the number of leading elements to skip</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">skip</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">takeWhile</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.</span>
-
-<span class="sd">        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">dropWhile</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.</span>
-
-<span class="sd">        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">dropWhile</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    From here this method mustn&#39;t be called on infinite stream</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="k">def</span> <span class="nf">sorted</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="nb">iter</span><span class="p">(</span><span class="nb">sorted</span><span class="p">(</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">)))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="nb">iter</span><span class="p">(</span><span class="nb">sorted</span><span class="p">(</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">))</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">peek</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">consumer</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</span>
-
-<span class="sd">        :param Consumer consumer: action to perform on the elements as they are consumed from the stream</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">peek</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">consumer</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-
-    <span class="k">def</span> <span class="nf">forEach</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">function</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Performs an action for each element of this stream.</span>
-
-<span class="sd">        :param Function function: action to perform on the elements</span>
-<span class="sd">        :return: None</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="n">function</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">anyMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether any elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if any elements of the stream match the provided predicate, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">any</span><span class="p">([</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">])</span>
-
-    <span class="k">def</span> <span class="nf">allMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether all elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">all</span><span class="p">([</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">])</span>
-
-    <span class="k">def</span> <span class="nf">noneMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether no elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">anyMatch</span><span class="p">(</span><span class="n">predicate</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">findFirst</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the first element of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.</span>
-
-<span class="sd">        :return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">of</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">findAny</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.</span>
-
-<span class="sd">        :return: an Optional describing some element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">findFirst</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">reduce</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">accumulator</span><span class="p">,</span> <span class="n">identity</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.</span>
-
-<span class="sd">        :param T identity: the identity value for the accumulating function - if not specified it will be the first element of the stream</span>
-<span class="sd">        :param Accumulator accumulator: function for combining two values</span>
-<span class="sd">        :return: the result of reduction</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">result</span> <span class="o">=</span> <span class="n">identity</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">result</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">):</span>
-                <span class="n">result</span> <span class="o">=</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="n">result</span> <span class="o">=</span> <span class="n">accumulator</span><span class="p">(</span><span class="n">result</span><span class="p">,</span> <span class="n">elem</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="n">result</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">min</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used</span>
-<span class="sd">        :return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">elements</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">min</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">),</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">min</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="nf">max</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used</span>
-<span class="sd">        :return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">elements</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">max</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">)))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">max</span><span class="p">(</span><span class="n">elements</span><span class="p">))</span>
-
-    <span class="k">def</span> <span class="nf">sum</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the sum of all elements of this stream. This is a special case of a reduction.</span>
-
-<span class="sd">        :return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">reduce</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">:</span> <span class="n">x</span> <span class="o">+</span> <span class="n">y</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">count</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the count of elements in this stream. This is a special case of a reduction.</span>
-
-<span class="sd">        :return: the count of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">count</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="n">count</span> <span class="o">+=</span> <span class="mi">1</span>
-
-        <span class="k">return</span> <span class="n">count</span>
-
-    <span class="k">def</span> <span class="nf">toList</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a list with the elements in this stream.</span>
-
-<span class="sd">        :return: the list of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">toSet</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a set with the elements in this stream.</span>
-
-<span class="sd">        :return: the set of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">set</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">toNumberStream</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="kn">from</span> <span class="nn">.numbers</span> <span class="kn">import</span> <span class="n">NumberStream</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="nf">toBooleanStream</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="kn">from</span> <span class="nn">.booleans</span> <span class="kn">import</span> <span class="n">BooleanStream</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__iter__</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an iterator over the elements in this stream.</span>
-
-<span class="sd">        :return: the iterator over the elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">iter</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-
-    <span class="k">def</span> <span class="fm">__eq__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">value</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Check if this stream is equal to the specified stream</span>
-
-<span class="sd">        :return: True if the streams match, False otherwise</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">toSet</span><span class="p">()</span> <span class="o">==</span> <span class="n">value</span><span class="o">.</span><span class="n">toSet</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>A sequence of elements supporting sequential operations.</p>
-
-<p>The following example illustrates an aggregate operation using
-Stream:</p>
-
-<pre><code>result = Stream(elements)
-                .filter(lambda w: w.getColor() == RED)
-                .map(lambda w: w.getWeight())
-                .sum()
-</code></pre>
-
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>stream.stream</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">from functools import cmp_to_key
+import random
+
+from .util.iterators import IteratorUtils
+from .util.optional import Optional
+
+
+class Stream():
+
+    &#34;&#34;&#34;
+    A sequence of elements supporting sequential operations.
+
+    The following example illustrates an aggregate operation using
+    Stream:
+
+        result = Stream(elements)
+                        .filter(lambda w: w.getColor() == RED)
+                        .map(lambda w: w.getWeight())
+                        .sum()
+
+    A stream pipeline, like the elements example above, can be viewed as a query on the stream source.
+
+    A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, &#34;forked&#34; streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.
+    &#34;&#34;&#34;
+
+    &#34;&#34;&#34;
+    Static Methods
+    &#34;&#34;&#34;
+
+    @staticmethod
+    def empty():
+        &#39;&#39;&#39;
+        Returns an empty sequential Stream.
+
+        :return: an empty sequential stream
+        &#39;&#39;&#39;
+        return Stream([])
+
+    @staticmethod
+    def of(elem):
+        &#39;&#39;&#39;
+        Returns a sequential Stream containing a single element.
+
+        :param T elem: the single element
+        :return: a singleton sequential stream
+        &#39;&#39;&#39;
+        return Stream(iter([elem]))
+
+    @staticmethod
+    def of(*elements):
+        &#39;&#39;&#39;
+        Returns a sequential ordered stream whose elements are the specified values.
+
+        :param *T elements: the elements of the new stream
+        :return: the new stream
+        &#39;&#39;&#39;
+        return Stream(iter(list(elements)))
+
+    @staticmethod
+    def ofNullable(elem):
+        &#39;&#39;&#39;
+        Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.
+
+        :param T elem: the single element
+        :return: a stream with a single element if the specified element is non-null, otherwise an empty stream
+        &#39;&#39;&#39;
+        return Stream.of(elem) if elem is not None else Stream.empty()
+
+    @staticmethod
+    def iterate(seed, operator):
+        &#39;&#39;&#39;
+        Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.
+
+        :param T seed: the initial element
+        :param UnaryOperator operator: a function to be applied to the previous element to produce a new element
+        :return: a new sequential Stream
+        &#39;&#39;&#39;
+        return Stream(IteratorUtils.iterate(seed, operator))
+
+    @staticmethod
+    def generate(supplier):
+        &#39;&#39;&#39;
+        Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.
+
+        :param Supplier supplier: the Supplier of generated elements
+        :return: a new infinite sequential unordered Stream
+        &#39;&#39;&#39;
+        return Stream(IteratorUtils.generate(supplier))
+
+    @staticmethod
+    def concat(*streams):
+        &#39;&#39;&#39;
+        Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.
+
+        :param *Stream streams: the streams to concat
+        :return: the concatenation of the input streams
+        &#39;&#39;&#39;
+        return Stream(IteratorUtils.concat(*streams))
+
+    @staticmethod
+    def constant(element):
+        &#39;&#39;&#39;
+        Return an infinite sequential stream where each element is the passed element
+
+        :param T elem: the element
+        :return: the new stream made of @element
+        &#39;&#39;&#39;
+        return Stream.generate(lambda: element)
+
+    &#34;&#34;&#34;
+    Normal Methods
+    &#34;&#34;&#34;
+
+    def __init__(self, iterable):
+        self.iterable = iterable
+
+    def filter(self, predicate):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.
+
+        :param function predicate: predicate to apply to each element to determine if it should be included
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.filter(self.iterable, predicate)
+        return self
+
+    def map(self, mapper):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the results of applying the given function to the elements of this stream.
+
+        :param function mapper: function to apply to each element
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.map(self.iterable, mapper)
+        return self
+
+    def flatMap(self, flatMapper):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)
+
+        :param function flatMapper: function to apply to each element which produces a stream of new values
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.flatMap(self.iterable, flatMapper)
+        return self
+
+    def distinct(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the distinct elements of this stream.
+
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.distinct(self.iterable)
+        return self
+
+    def limit(self, count):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.
+
+        :param int count:  the number of elements the stream should be limited to
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.limit(self.iterable, count)
+        return self
+
+    def skip(self, count):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.
+
+        :param int count:  the number of leading elements to skip
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.skip(self.iterable, count)
+        return self
+
+    def takeWhile(self, predicate):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.
+
+        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.takeWhile(self.iterable, predicate)
+        return self
+
+    def dropWhile(self, predicate):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.
+
+        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.dropWhile(self.iterable, predicate)
+        return self
+
+    &#34;&#34;&#34;
+    From here this method mustn&#39;t be called on infinite stream
+    &#34;&#34;&#34;
+
+    def sorted(self, comparator=None):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.
+
+        :param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = iter(sorted(
+            self.iterable, key=cmp_to_key(comparator))) if comparator is not None else iter(sorted(
+                self.iterable))
+        return self
+
+    def peek(self, consumer):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.
+
+        :param Consumer consumer: action to perform on the elements as they are consumed from the stream
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.peek(self.iterable, consumer)
+        return self
+
+    def forEach(self, function):
+        &#39;&#39;&#39;
+        Performs an action for each element of this stream.
+
+        :param Function function: action to perform on the elements
+        :return: None
+        &#39;&#39;&#39;
+        for elem in self.iterable:
+            function(elem)
+
+    def anyMatch(self, predicate):
+        &#39;&#39;&#39;
+        Returns whether any elements of this stream match the provided predicate.
+
+        :param Predicate predicate: predicate to apply to elements of this stream
+        :return: True if any elements of the stream match the provided predicate, otherwise False
+        &#39;&#39;&#39;
+        return any([predicate(elem) for elem in self.iterable])
+
+    def allMatch(self, predicate):
+        &#39;&#39;&#39;
+        Returns whether all elements of this stream match the provided predicate.
+
+        :param Predicate predicate: predicate to apply to elements of this stream
+        :return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False
+        &#39;&#39;&#39;
+        return all([predicate(elem) for elem in self.iterable])
+
+    def noneMatch(self, predicate):
+        &#39;&#39;&#39;
+        Returns whether no elements of this stream match the provided predicate.
+
+        :param Predicate predicate: predicate to apply to elements of this stream
+        :return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False
+        &#39;&#39;&#39;
+        return not self.anyMatch(predicate)
+
+    def findFirst(self, predicate=None):
+        &#39;&#39;&#39;
+        Returns an Optional describing the first element (with optional filtering by a given predicate) of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.
+
+        :param Predicate predicate: optional predicate to apply to elements of this stream
+        :return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        if predicate:
+            self.filter(predicate)
+
+        for elem in self.iterable:
+            return Optional.of(elem)
+        return Optional.ofNullable(None)
+
+    def findAny(self):
+        &#39;&#39;&#39;
+        Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.
+
+        :return: an Optional describing some element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        return self.findFirst()
+
+    def reduce(self, accumulator, identity=None):
+        &#39;&#39;&#39;
+        Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.
+
+        :param T identity: the identity value for the accumulating function - if not specified it will be the first element of the stream
+        :param Accumulator accumulator: function for combining two values
+        :return: the result of reduction
+        &#39;&#39;&#39;
+        result = identity
+        for elem in self.iterable:
+            if(result is None):
+                result = elem
+            else:
+                result = accumulator(result, elem)
+        return Optional.ofNullable(result)
+
+    def min(self, comparator=None):
+        &#39;&#39;&#39;
+        Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.
+
+        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+        :return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        elements = list(self.iterable)
+        if len(elements) == 0:
+            return Optional.empty()
+
+        return Optional.ofNullable(min(elements, key=cmp_to_key(comparator), default=None)) if comparator is not None else Optional.ofNullable(min(elements, default=None))
+
+    def max(self, comparator=None):
+        &#39;&#39;&#39;
+        Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.
+
+        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+        :return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        elements = list(self.iterable)
+        if len(elements) == 0:
+            return Optional.empty()
+        return Optional.ofNullable(max(elements, key=cmp_to_key(comparator))) if comparator is not None else Optional.ofNullable(max(elements))
+
+    def sum(self):
+        &#39;&#39;&#39;
+        Returns the sum of all elements of this stream. This is a special case of a reduction.
+
+        :return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        return self.reduce(lambda x, y: x + y)
+
+    def count(self):
+        &#39;&#39;&#39;
+        Returns the count of elements in this stream. This is a special case of a reduction.
+
+        :return: the count of elements in this stream
+        &#39;&#39;&#39;
+        count = 0
+        for elem in self.iterable:
+            count += 1
+
+        return count
+
+    def toList(self):
+        &#39;&#39;&#39;
+        Returns a list with the elements in this stream.
+
+        :return: the list of elements in this stream
+        &#39;&#39;&#39;
+        return list(self.iterable)
+
+    def toSet(self):
+        &#39;&#39;&#39;
+        Returns a set with the elements in this stream.
+
+        :return: the set of elements in this stream
+        &#39;&#39;&#39;
+        return set(self.iterable)
+
+    def toNumberStream(self):
+        from .numbers import NumberStream
+        return NumberStream(self)
+
+    def toBooleanStream(self):
+        from .booleans import BooleanStream
+        return BooleanStream(self)
+
+    def __iter__(self):
+        &#39;&#39;&#39;
+        Returns an iterator over the elements in this stream.
+
+        :return: the iterator over the elements in this stream
+        &#39;&#39;&#39;
+        return iter(self.iterable)
+
+    def __eq__(self, value):
+        &#39;&#39;&#39;
+        Check if this stream is equal to the specified stream
+
+        :return: True if the streams match, False otherwise
+        &#39;&#39;&#39;
+        return self.toSet() == value.toSet()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="stream.stream.Stream"><code class="flex name class">
+<span>class <span class="ident">Stream</span></span>
+<span>(</span><span>iterable)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A sequence of elements supporting sequential operations.</p>
+<p>The following example illustrates an aggregate operation using</p>
+<h2 id="stream">Stream</h2>
+<p>result = Stream(elements)
+.filter(lambda w: w.getColor() == RED)
+.map(lambda w: w.getWeight())
+.sum()</p>
 <p>A stream pipeline, like the elements example above, can be viewed as a query on the stream source.</p>
+<p>A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, "forked" streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Stream():
 
-<p>A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, "forked" streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.</p>
-</div>
+    &#34;&#34;&#34;
+    A sequence of elements supporting sequential operations.
 
+    The following example illustrates an aggregate operation using
+    Stream:
 
-                            <div id="Stream.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.__init__">#&nbsp;&nbsp</a>
+        result = Stream(elements)
+                        .filter(lambda w: w.getColor() == RED)
+                        .map(lambda w: w.getWeight())
+                        .sum()
 
-        
-            <span class="name">Stream</span><span class="signature">(iterable)</span>    </div>
+    A stream pipeline, like the elements example above, can be viewed as a query on the stream source.
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">iterable</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">iterable</span>
-</pre></div>
+    A stream should be operated on (invoking an intermediate or terminal stream operation) only once. This rules out, for example, &#34;forked&#34; streams, where the same source feeds two or more pipelines, or multiple traversals of the same stream. A stream implementation may raise Exception if it detects that the stream is being reused.
+    &#34;&#34;&#34;
 
-        </details>
+    &#34;&#34;&#34;
+    Static Methods
+    &#34;&#34;&#34;
 
-    
+    @staticmethod
+    def empty():
+        &#39;&#39;&#39;
+        Returns an empty sequential Stream.
 
-                            </div>
-                            <div id="Stream.empty" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.empty">#&nbsp;&nbsp</a>
+        :return: an empty sequential stream
+        &#39;&#39;&#39;
+        return Stream([])
 
-                <div class="decorator">@staticmethod</div>
+    @staticmethod
+    def of(elem):
+        &#39;&#39;&#39;
+        Returns a sequential Stream containing a single element.
 
-            <span class="def">def</span>
-            <span class="name">empty</span><span class="signature">()</span>:
-    </div>
+        :param T elem: the single element
+        :return: a singleton sequential stream
+        &#39;&#39;&#39;
+        return Stream(iter([elem]))
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">empty</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an empty sequential Stream.</span>
+    @staticmethod
+    def of(*elements):
+        &#39;&#39;&#39;
+        Returns a sequential ordered stream whose elements are the specified values.
 
-<span class="sd">        :return: an empty sequential stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">([])</span>
-</pre></div>
+        :param *T elements: the elements of the new stream
+        :return: the new stream
+        &#39;&#39;&#39;
+        return Stream(iter(list(elements)))
 
-        </details>
+    @staticmethod
+    def ofNullable(elem):
+        &#39;&#39;&#39;
+        Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.
 
-            <div class="docstring"><p>Returns an empty sequential Stream.</p>
+        :param T elem: the single element
+        :return: a stream with a single element if the specified element is non-null, otherwise an empty stream
+        &#39;&#39;&#39;
+        return Stream.of(elem) if elem is not None else Stream.empty()
 
-<p>:return: an empty sequential stream</p>
-</div>
+    @staticmethod
+    def iterate(seed, operator):
+        &#39;&#39;&#39;
+        Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.
 
+        :param T seed: the initial element
+        :param UnaryOperator operator: a function to be applied to the previous element to produce a new element
+        :return: a new sequential Stream
+        &#39;&#39;&#39;
+        return Stream(IteratorUtils.iterate(seed, operator))
 
-                            </div>
-                            <div id="Stream.of" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.of">#&nbsp;&nbsp</a>
+    @staticmethod
+    def generate(supplier):
+        &#39;&#39;&#39;
+        Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.
 
-                <div class="decorator">@staticmethod</div>
+        :param Supplier supplier: the Supplier of generated elements
+        :return: a new infinite sequential unordered Stream
+        &#39;&#39;&#39;
+        return Stream(IteratorUtils.generate(supplier))
 
-            <span class="def">def</span>
-            <span class="name">of</span><span class="signature">(*elements)</span>:
-    </div>
+    @staticmethod
+    def concat(*streams):
+        &#39;&#39;&#39;
+        Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="o">*</span><span class="n">elements</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential ordered stream whose elements are the specified values.</span>
+        :param *Stream streams: the streams to concat
+        :return: the concatenation of the input streams
+        &#39;&#39;&#39;
+        return Stream(IteratorUtils.concat(*streams))
 
-<span class="sd">        :param *T elements: the elements of the new stream</span>
-<span class="sd">        :return: the new stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="nb">iter</span><span class="p">(</span><span class="nb">list</span><span class="p">(</span><span class="n">elements</span><span class="p">)))</span>
-</pre></div>
+    @staticmethod
+    def constant(element):
+        &#39;&#39;&#39;
+        Return an infinite sequential stream where each element is the passed element
 
-        </details>
+        :param T elem: the element
+        :return: the new stream made of @element
+        &#39;&#39;&#39;
+        return Stream.generate(lambda: element)
 
-            <div class="docstring"><p>Returns a sequential ordered stream whose elements are the specified values.</p>
+    &#34;&#34;&#34;
+    Normal Methods
+    &#34;&#34;&#34;
 
-<p>:param *T elements: the elements of the new stream
-:return: the new stream</p>
-</div>
+    def __init__(self, iterable):
+        self.iterable = iterable
 
+    def filter(self, predicate):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.
 
-                            </div>
-                            <div id="Stream.ofNullable" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.ofNullable">#&nbsp;&nbsp</a>
+        :param function predicate: predicate to apply to each element to determine if it should be included
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.filter(self.iterable, predicate)
+        return self
 
-                <div class="decorator">@staticmethod</div>
+    def map(self, mapper):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the results of applying the given function to the elements of this stream.
 
-            <span class="def">def</span>
-            <span class="name">ofNullable</span><span class="signature">(elem)</span>:
-    </div>
+        :param function mapper: function to apply to each element
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.map(self.iterable, mapper)
+        return self
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">ofNullable</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.</span>
+    def flatMap(self, flatMapper):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)
 
-<span class="sd">        :param T elem: the single element</span>
-<span class="sd">        :return: a stream with a single element if the specified element is non-null, otherwise an empty stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="o">.</span><span class="n">of</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">if</span> <span class="n">elem</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Stream</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-</pre></div>
+        :param function flatMapper: function to apply to each element which produces a stream of new values
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.flatMap(self.iterable, flatMapper)
+        return self
 
-        </details>
+    def distinct(self):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the distinct elements of this stream.
 
-            <div class="docstring"><p>Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.</p>
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.distinct(self.iterable)
+        return self
 
-<p>:param T elem: the single element
-:return: a stream with a single element if the specified element is non-null, otherwise an empty stream</p>
-</div>
+    def limit(self, count):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.
 
+        :param int count:  the number of elements the stream should be limited to
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.limit(self.iterable, count)
+        return self
 
-                            </div>
-                            <div id="Stream.iterate" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.iterate">#&nbsp;&nbsp</a>
+    def skip(self, count):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.
 
-                <div class="decorator">@staticmethod</div>
+        :param int count:  the number of leading elements to skip
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.skip(self.iterable, count)
+        return self
 
-            <span class="def">def</span>
-            <span class="name">iterate</span><span class="signature">(seed, operator)</span>:
-    </div>
+    def takeWhile(self, predicate):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.</span>
+        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.takeWhile(self.iterable, predicate)
+        return self
 
-<span class="sd">        :param T seed: the initial element</span>
-<span class="sd">        :param UnaryOperator operator: a function to be applied to the previous element to produce a new element</span>
-<span class="sd">        :return: a new sequential Stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">))</span>
-</pre></div>
+    def dropWhile(self, predicate):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.
 
-        </details>
+        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.dropWhile(self.iterable, predicate)
+        return self
 
-            <div class="docstring"><p>Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.</p>
+    &#34;&#34;&#34;
+    From here this method mustn&#39;t be called on infinite stream
+    &#34;&#34;&#34;
 
+    def sorted(self, comparator=None):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.
+
+        :param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = iter(sorted(
+            self.iterable, key=cmp_to_key(comparator))) if comparator is not None else iter(sorted(
+                self.iterable))
+        return self
+
+    def peek(self, consumer):
+        &#39;&#39;&#39;
+        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.
+
+        :param Consumer consumer: action to perform on the elements as they are consumed from the stream
+        :return: self
+        &#39;&#39;&#39;
+        self.iterable = IteratorUtils.peek(self.iterable, consumer)
+        return self
+
+    def forEach(self, function):
+        &#39;&#39;&#39;
+        Performs an action for each element of this stream.
+
+        :param Function function: action to perform on the elements
+        :return: None
+        &#39;&#39;&#39;
+        for elem in self.iterable:
+            function(elem)
+
+    def anyMatch(self, predicate):
+        &#39;&#39;&#39;
+        Returns whether any elements of this stream match the provided predicate.
+
+        :param Predicate predicate: predicate to apply to elements of this stream
+        :return: True if any elements of the stream match the provided predicate, otherwise False
+        &#39;&#39;&#39;
+        return any([predicate(elem) for elem in self.iterable])
+
+    def allMatch(self, predicate):
+        &#39;&#39;&#39;
+        Returns whether all elements of this stream match the provided predicate.
+
+        :param Predicate predicate: predicate to apply to elements of this stream
+        :return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False
+        &#39;&#39;&#39;
+        return all([predicate(elem) for elem in self.iterable])
+
+    def noneMatch(self, predicate):
+        &#39;&#39;&#39;
+        Returns whether no elements of this stream match the provided predicate.
+
+        :param Predicate predicate: predicate to apply to elements of this stream
+        :return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False
+        &#39;&#39;&#39;
+        return not self.anyMatch(predicate)
+
+    def findFirst(self, predicate=None):
+        &#39;&#39;&#39;
+        Returns an Optional describing the first element (with optional filtering by a given predicate) of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.
+
+        :param Predicate predicate: optional predicate to apply to elements of this stream
+        :return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        if predicate:
+            self.filter(predicate)
+
+        for elem in self.iterable:
+            return Optional.of(elem)
+        return Optional.ofNullable(None)
+
+    def findAny(self):
+        &#39;&#39;&#39;
+        Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.
+
+        :return: an Optional describing some element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        return self.findFirst()
+
+    def reduce(self, accumulator, identity=None):
+        &#39;&#39;&#39;
+        Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.
+
+        :param T identity: the identity value for the accumulating function - if not specified it will be the first element of the stream
+        :param Accumulator accumulator: function for combining two values
+        :return: the result of reduction
+        &#39;&#39;&#39;
+        result = identity
+        for elem in self.iterable:
+            if(result is None):
+                result = elem
+            else:
+                result = accumulator(result, elem)
+        return Optional.ofNullable(result)
+
+    def min(self, comparator=None):
+        &#39;&#39;&#39;
+        Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.
+
+        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+        :return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        elements = list(self.iterable)
+        if len(elements) == 0:
+            return Optional.empty()
+
+        return Optional.ofNullable(min(elements, key=cmp_to_key(comparator), default=None)) if comparator is not None else Optional.ofNullable(min(elements, default=None))
+
+    def max(self, comparator=None):
+        &#39;&#39;&#39;
+        Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.
+
+        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+        :return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        elements = list(self.iterable)
+        if len(elements) == 0:
+            return Optional.empty()
+        return Optional.ofNullable(max(elements, key=cmp_to_key(comparator))) if comparator is not None else Optional.ofNullable(max(elements))
+
+    def sum(self):
+        &#39;&#39;&#39;
+        Returns the sum of all elements of this stream. This is a special case of a reduction.
+
+        :return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty
+        &#39;&#39;&#39;
+        return self.reduce(lambda x, y: x + y)
+
+    def count(self):
+        &#39;&#39;&#39;
+        Returns the count of elements in this stream. This is a special case of a reduction.
+
+        :return: the count of elements in this stream
+        &#39;&#39;&#39;
+        count = 0
+        for elem in self.iterable:
+            count += 1
+
+        return count
+
+    def toList(self):
+        &#39;&#39;&#39;
+        Returns a list with the elements in this stream.
+
+        :return: the list of elements in this stream
+        &#39;&#39;&#39;
+        return list(self.iterable)
+
+    def toSet(self):
+        &#39;&#39;&#39;
+        Returns a set with the elements in this stream.
+
+        :return: the set of elements in this stream
+        &#39;&#39;&#39;
+        return set(self.iterable)
+
+    def toNumberStream(self):
+        from .numbers import NumberStream
+        return NumberStream(self)
+
+    def toBooleanStream(self):
+        from .booleans import BooleanStream
+        return BooleanStream(self)
+
+    def __iter__(self):
+        &#39;&#39;&#39;
+        Returns an iterator over the elements in this stream.
+
+        :return: the iterator over the elements in this stream
+        &#39;&#39;&#39;
+        return iter(self.iterable)
+
+    def __eq__(self, value):
+        &#39;&#39;&#39;
+        Check if this stream is equal to the specified stream
+
+        :return: True if the streams match, False otherwise
+        &#39;&#39;&#39;
+        return self.toSet() == value.toSet()</code></pre>
+</details>
+<h3>Subclasses</h3>
+<ul class="hlist">
+<li><a title="stream.booleans.BooleanStream" href="booleans.html#stream.booleans.BooleanStream">BooleanStream</a></li>
+<li><a title="stream.numbers.NumberStream" href="numbers.html#stream.numbers.NumberStream">NumberStream</a></li>
+</ul>
+<h3>Static methods</h3>
+<dl>
+<dt id="stream.stream.Stream.concat"><code class="name flex">
+<span>def <span class="ident">concat</span></span>(<span>*streams)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.</p>
+<p>:param *Stream streams: the streams to concat
+:return: the concatenation of the input streams</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def concat(*streams):
+    &#39;&#39;&#39;
+    Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.
+
+    :param *Stream streams: the streams to concat
+    :return: the concatenation of the input streams
+    &#39;&#39;&#39;
+    return Stream(IteratorUtils.concat(*streams))</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.constant"><code class="name flex">
+<span>def <span class="ident">constant</span></span>(<span>element)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Return an infinite sequential stream where each element is the passed element</p>
+<p>:param T elem: the element
+:return: the new stream made of @element</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def constant(element):
+    &#39;&#39;&#39;
+    Return an infinite sequential stream where each element is the passed element
+
+    :param T elem: the element
+    :return: the new stream made of @element
+    &#39;&#39;&#39;
+    return Stream.generate(lambda: element)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.empty"><code class="name flex">
+<span>def <span class="ident">empty</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an empty sequential Stream.</p>
+<p>:return: an empty sequential stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def empty():
+    &#39;&#39;&#39;
+    Returns an empty sequential Stream.
+
+    :return: an empty sequential stream
+    &#39;&#39;&#39;
+    return Stream([])</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.generate"><code class="name flex">
+<span>def <span class="ident">generate</span></span>(<span>supplier)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.</p>
+<p>:param Supplier supplier: the Supplier of generated elements
+:return: a new infinite sequential unordered Stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def generate(supplier):
+    &#39;&#39;&#39;
+    Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.
+
+    :param Supplier supplier: the Supplier of generated elements
+    :return: a new infinite sequential unordered Stream
+    &#39;&#39;&#39;
+    return Stream(IteratorUtils.generate(supplier))</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.iterate"><code class="name flex">
+<span>def <span class="ident">iterate</span></span>(<span>seed, operator)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.</p>
 <p>:param T seed: the initial element
 :param UnaryOperator operator: a function to be applied to the previous element to produce a new element
-:return: a new sequential Stream</p>
-</div>
+:return: a new sequential Stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def iterate(seed, operator):
+    &#39;&#39;&#39;
+    Returns an infinite sequential ordered Stream produced by iterative application of a function f to an initial element seed, producing a Stream consisting of seed, f(seed), f(f(seed)), etc.
 
+    :param T seed: the initial element
+    :param UnaryOperator operator: a function to be applied to the previous element to produce a new element
+    :return: a new sequential Stream
+    &#39;&#39;&#39;
+    return Stream(IteratorUtils.iterate(seed, operator))</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.of"><code class="name flex">
+<span>def <span class="ident">of</span></span>(<span>*elements)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a sequential ordered stream whose elements are the specified values.</p>
+<p>:param *T elements: the elements of the new stream
+:return: the new stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def of(*elements):
+    &#39;&#39;&#39;
+    Returns a sequential ordered stream whose elements are the specified values.
 
-                            </div>
-                            <div id="Stream.generate" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.generate">#&nbsp;&nbsp</a>
+    :param *T elements: the elements of the new stream
+    :return: the new stream
+    &#39;&#39;&#39;
+    return Stream(iter(list(elements)))</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.ofNullable"><code class="name flex">
+<span>def <span class="ident">ofNullable</span></span>(<span>elem)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.</p>
+<p>:param T elem: the single element
+:return: a stream with a single element if the specified element is non-null, otherwise an empty stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def ofNullable(elem):
+    &#39;&#39;&#39;
+    Returns a sequential Stream containing a single element, if non-null, otherwise returns an empty Stream.
 
-                <div class="decorator">@staticmethod</div>
+    :param T elem: the single element
+    :return: a stream with a single element if the specified element is non-null, otherwise an empty stream
+    &#39;&#39;&#39;
+    return Stream.of(elem) if elem is not None else Stream.empty()</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="stream.stream.Stream.allMatch"><code class="name flex">
+<span>def <span class="ident">allMatch</span></span>(<span>self, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns whether all elements of this stream match the provided predicate.</p>
+<p>:param Predicate predicate: predicate to apply to elements of this stream
+:return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def allMatch(self, predicate):
+    &#39;&#39;&#39;
+    Returns whether all elements of this stream match the provided predicate.
 
-            <span class="def">def</span>
-            <span class="name">generate</span><span class="signature">(supplier)</span>:
-    </div>
+    :param Predicate predicate: predicate to apply to elements of this stream
+    :return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False
+    &#39;&#39;&#39;
+    return all([predicate(elem) for elem in self.iterable])</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.anyMatch"><code class="name flex">
+<span>def <span class="ident">anyMatch</span></span>(<span>self, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns whether any elements of this stream match the provided predicate.</p>
+<p>:param Predicate predicate: predicate to apply to elements of this stream
+:return: True if any elements of the stream match the provided predicate, otherwise False</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def anyMatch(self, predicate):
+    &#39;&#39;&#39;
+    Returns whether any elements of this stream match the provided predicate.
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">generate</span><span class="p">(</span><span class="n">supplier</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.</span>
+    :param Predicate predicate: predicate to apply to elements of this stream
+    :return: True if any elements of the stream match the provided predicate, otherwise False
+    &#39;&#39;&#39;
+    return any([predicate(elem) for elem in self.iterable])</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.count"><code class="name flex">
+<span>def <span class="ident">count</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the count of elements in this stream. This is a special case of a reduction.</p>
+<p>:return: the count of elements in this stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def count(self):
+    &#39;&#39;&#39;
+    Returns the count of elements in this stream. This is a special case of a reduction.
 
-<span class="sd">        :param Supplier supplier: the Supplier of generated elements</span>
-<span class="sd">        :return: a new infinite sequential unordered Stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="n">supplier</span><span class="p">))</span>
-</pre></div>
+    :return: the count of elements in this stream
+    &#39;&#39;&#39;
+    count = 0
+    for elem in self.iterable:
+        count += 1
 
-        </details>
+    return count</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.distinct"><code class="name flex">
+<span>def <span class="ident">distinct</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the distinct elements of this stream.</p>
+<p>:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def distinct(self):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the distinct elements of this stream.
 
-            <div class="docstring"><p>Returns an infinite sequential unordered stream where each element is generated by the provided Supplier. This is suitable for generating constant streams, streams of random elements, etc.</p>
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.distinct(self.iterable)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.dropWhile"><code class="name flex">
+<span>def <span class="ident">dropWhile</span></span>(<span>self, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.</p>
+<p>:param Predicate predicate:
+predicate to apply to elements to determine the longest prefix of elements.
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def dropWhile(self, predicate):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.
 
-<p>:param Supplier supplier: the Supplier of generated elements
-:return: a new infinite sequential unordered Stream</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.concat" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.concat">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">concat</span><span class="signature">(*streams)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">concat</span><span class="p">(</span><span class="o">*</span><span class="n">streams</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.</span>
-
-<span class="sd">        :param *Stream streams: the streams to concat</span>
-<span class="sd">        :return: the concatenation of the input streams</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="p">(</span><span class="n">IteratorUtils</span><span class="o">.</span><span class="n">concat</span><span class="p">(</span><span class="o">*</span><span class="n">streams</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Creates a lazily concatenated stream whose elements are all the elements of the first stream followed by all the elements of the second stream and so on.</p>
-
-<p>:param *Stream streams: the streams to concat
-:return: the concatenation of the input streams</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.constant" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.constant">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">constant</span><span class="signature">(element)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">constant</span><span class="p">(</span><span class="n">element</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Return an infinite sequential stream where each element is the passed element</span>
-
-<span class="sd">        :param T elem: the element</span>
-<span class="sd">        :return: the new stream made of @element</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Stream</span><span class="o">.</span><span class="n">generate</span><span class="p">(</span><span class="k">lambda</span><span class="p">:</span> <span class="n">element</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Return an infinite sequential stream where each element is the passed element</p>
-
-<p>:param T elem: the element
-:return: the new stream made of @element</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.filter" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.filter">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">filter</span><span class="signature">(self, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</span>
-
-<span class="sd">        :param function predicate: predicate to apply to each element to determine if it should be included</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">filter</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</p>
-
+    :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.dropWhile(self.iterable, predicate)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.filter"><code class="name flex">
+<span>def <span class="ident">filter</span></span>(<span>self, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</p>
 <p>:param function predicate: predicate to apply to each element to determine if it should be included
-:return: self</p>
-</div>
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def filter(self, predicate):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.
 
+    :param function predicate: predicate to apply to each element to determine if it should be included
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.filter(self.iterable, predicate)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.findAny"><code class="name flex">
+<span>def <span class="ident">findAny</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.</p>
+<p>:return: an Optional describing some element of this stream, or an empty Optional if the stream is empty</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def findAny(self):
+    &#39;&#39;&#39;
+    Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.
 
-                            </div>
-                            <div id="Stream.map" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.map">#&nbsp;&nbsp</a>
+    :return: an Optional describing some element of this stream, or an empty Optional if the stream is empty
+    &#39;&#39;&#39;
+    return self.findFirst()</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.findFirst"><code class="name flex">
+<span>def <span class="ident">findFirst</span></span>(<span>self, predicate=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an Optional describing the first element (with optional filtering by a given predicate) of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.</p>
+<p>:param Predicate predicate: optional predicate to apply to elements of this stream
+:return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def findFirst(self, predicate=None):
+    &#39;&#39;&#39;
+    Returns an Optional describing the first element (with optional filtering by a given predicate) of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.
 
-        
-            <span class="def">def</span>
-            <span class="name">map</span><span class="signature">(self, mapper)</span>:
-    </div>
+    :param Predicate predicate: optional predicate to apply to elements of this stream
+    :return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty
+    &#39;&#39;&#39;
+    if predicate:
+        self.filter(predicate)
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the results of applying the given function to the elements of this stream.</span>
-
-<span class="sd">        :param function mapper: function to apply to each element</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">map</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the results of applying the given function to the elements of this stream.</p>
-
-<p>:param function mapper: function to apply to each element
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.flatMap" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.flatMap">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">flatMap</span><span class="signature">(self, flatMapper)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">flatMap</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">flatMapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)</span>
-
-<span class="sd">        :param function flatMapper: function to apply to each element which produces a stream of new values</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">flatMap</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">flatMapper</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)</p>
-
+    for elem in self.iterable:
+        return Optional.of(elem)
+    return Optional.ofNullable(None)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.flatMap"><code class="name flex">
+<span>def <span class="ident">flatMap</span></span>(<span>self, flatMapper)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)</p>
 <p>:param function flatMapper: function to apply to each element which produces a stream of new values
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.distinct" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.distinct">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">distinct</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">distinct</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the distinct elements of this stream.</span>
-
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">distinct</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the distinct elements of this stream.</p>
-
-<p>:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.limit" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.limit">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">limit</span><span class="signature">(self, count)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">limit</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.</span>
-
-<span class="sd">        :param int count:  the number of elements the stream should be limited to</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">limit</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.</p>
-
-<p>:param int count:  the number of elements the stream should be limited to
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.skip" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.skip">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">skip</span><span class="signature">(self, count)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">skip</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.</span>
-
-<span class="sd">        :param int count:  the number of leading elements to skip</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">skip</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.</p>
-
-<p>:param int count:  the number of leading elements to skip
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.takeWhile" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.takeWhile">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">takeWhile</span><span class="signature">(self, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">takeWhile</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.</span>
-
-<span class="sd">        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">takeWhile</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.</p>
-
-<p>:param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.dropWhile" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.dropWhile">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">dropWhile</span><span class="signature">(self, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">dropWhile</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.</span>
-
-<span class="sd">        :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">dropWhile</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the remaining elements of this stream after dropping the longest prefix of elements that match the given predicate.</p>
-
-<p>:param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.sorted" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.sorted">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">sorted</span><span class="signature">(self, comparator=None)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">sorted</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="nb">iter</span><span class="p">(</span><span class="nb">sorted</span><span class="p">(</span>
-            <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">)))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="nb">iter</span><span class="p">(</span><span class="nb">sorted</span><span class="p">(</span>
-                <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">))</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.</p>
-
-<p>:param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.peek" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.peek">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">peek</span><span class="signature">(self, consumer)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">peek</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">consumer</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</span>
-
-<span class="sd">        :param Consumer consumer: action to perform on the elements as they are consumed from the stream</span>
-<span class="sd">        :return: self</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span> <span class="o">=</span> <span class="n">IteratorUtils</span><span class="o">.</span><span class="n">peek</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">,</span> <span class="n">consumer</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</p>
-
-<p>:param Consumer consumer: action to perform on the elements as they are consumed from the stream
-:return: self</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.forEach" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.forEach">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">forEach</span><span class="signature">(self, function)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">forEach</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">function</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Performs an action for each element of this stream.</span>
-
-<span class="sd">        :param Function function: action to perform on the elements</span>
-<span class="sd">        :return: None</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="n">function</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Performs an action for each element of this stream.</p>
-
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def flatMap(self, flatMapper):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the results of replacing each element of this stream with the contents of a mapped stream produced by applying the provided mapping function to each element. Each mapped stream is closed after its contents have been placed into this stream. (If a mapped stream is null an empty stream is used, instead.)
+
+    :param function flatMapper: function to apply to each element which produces a stream of new values
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.flatMap(self.iterable, flatMapper)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.forEach"><code class="name flex">
+<span>def <span class="ident">forEach</span></span>(<span>self, function)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs an action for each element of this stream.</p>
 <p>:param Function function: action to perform on the elements
-:return: None</p>
-</div>
+:return: None</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def forEach(self, function):
+    &#39;&#39;&#39;
+    Performs an action for each element of this stream.
 
+    :param Function function: action to perform on the elements
+    :return: None
+    &#39;&#39;&#39;
+    for elem in self.iterable:
+        function(elem)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.limit"><code class="name flex">
+<span>def <span class="ident">limit</span></span>(<span>self, count)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.</p>
+<p>:param int count:
+the number of elements the stream should be limited to
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def limit(self, count):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream, truncated to be no longer than maxSize in length.
 
-                            </div>
-                            <div id="Stream.anyMatch" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.anyMatch">#&nbsp;&nbsp</a>
+    :param int count:  the number of elements the stream should be limited to
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.limit(self.iterable, count)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.map"><code class="name flex">
+<span>def <span class="ident">map</span></span>(<span>self, mapper)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the results of applying the given function to the elements of this stream.</p>
+<p>:param function mapper: function to apply to each element
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def map(self, mapper):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the results of applying the given function to the elements of this stream.
 
-        
-            <span class="def">def</span>
-            <span class="name">anyMatch</span><span class="signature">(self, predicate)</span>:
-    </div>
+    :param function mapper: function to apply to each element
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.map(self.iterable, mapper)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.max"><code class="name flex">
+<span>def <span class="ident">max</span></span>(<span>self, comparator=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.</p>
+<p>:param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+:return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def max(self, comparator=None):
+    &#39;&#39;&#39;
+    Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">anyMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether any elements of this stream match the provided predicate.</span>
+    :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+    :return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty
+    &#39;&#39;&#39;
+    elements = list(self.iterable)
+    if len(elements) == 0:
+        return Optional.empty()
+    return Optional.ofNullable(max(elements, key=cmp_to_key(comparator))) if comparator is not None else Optional.ofNullable(max(elements))</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.min"><code class="name flex">
+<span>def <span class="ident">min</span></span>(<span>self, comparator=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.</p>
+<p>:param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+:return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def min(self, comparator=None):
+    &#39;&#39;&#39;
+    Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.
 
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if any elements of the stream match the provided predicate, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">any</span><span class="p">([</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">])</span>
-</pre></div>
+    :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
+    :return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty
+    &#39;&#39;&#39;
+    elements = list(self.iterable)
+    if len(elements) == 0:
+        return Optional.empty()
 
-        </details>
-
-            <div class="docstring"><p>Returns whether any elements of this stream match the provided predicate.</p>
-
+    return Optional.ofNullable(min(elements, key=cmp_to_key(comparator), default=None)) if comparator is not None else Optional.ofNullable(min(elements, default=None))</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.noneMatch"><code class="name flex">
+<span>def <span class="ident">noneMatch</span></span>(<span>self, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns whether no elements of this stream match the provided predicate.</p>
 <p>:param Predicate predicate: predicate to apply to elements of this stream
-:return: True if any elements of the stream match the provided predicate, otherwise False</p>
-</div>
+:return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def noneMatch(self, predicate):
+    &#39;&#39;&#39;
+    Returns whether no elements of this stream match the provided predicate.
 
+    :param Predicate predicate: predicate to apply to elements of this stream
+    :return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False
+    &#39;&#39;&#39;
+    return not self.anyMatch(predicate)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.peek"><code class="name flex">
+<span>def <span class="ident">peek</span></span>(<span>self, consumer)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.</p>
+<p>:param Consumer consumer: action to perform on the elements as they are consumed from the stream
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def peek(self, consumer):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream, additionally performing the provided action on each element as elements are consumed from the resulting stream.
 
-                            </div>
-                            <div id="Stream.allMatch" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.allMatch">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">allMatch</span><span class="signature">(self, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">allMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether all elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">all</span><span class="p">([</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">])</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns whether all elements of this stream match the provided predicate.</p>
-
-<p>:param Predicate predicate: predicate to apply to elements of this stream
-:return: True if either all elements of the stream match the provided predicate or the stream is empty, otherwise False</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.noneMatch" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.noneMatch">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">noneMatch</span><span class="signature">(self, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">noneMatch</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns whether no elements of this stream match the provided predicate.</span>
-
-<span class="sd">        :param Predicate predicate: predicate to apply to elements of this stream</span>
-<span class="sd">        :return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">anyMatch</span><span class="p">(</span><span class="n">predicate</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns whether no elements of this stream match the provided predicate.</p>
-
-<p>:param Predicate predicate: predicate to apply to elements of this stream
-:return: True if either no elements of the stream match the provided predicate or the stream is empty, otherwise False</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.findFirst" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.findFirst">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">findFirst</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">findFirst</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the first element of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.</span>
-
-<span class="sd">        :return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">of</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an Optional describing the first element of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.</p>
-
-<p>:return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.findAny" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.findAny">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">findAny</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">findAny</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.</span>
-
-<span class="sd">        :return: an Optional describing some element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">findFirst</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an Optional describing some element of the stream, or an empty Optional if the stream is empty.</p>
-
-<p>:return: an Optional describing some element of this stream, or an empty Optional if the stream is empty</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.reduce" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.reduce">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">reduce</span><span class="signature">(self, accumulator, identity=None)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">reduce</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">accumulator</span><span class="p">,</span> <span class="n">identity</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.</span>
-
-<span class="sd">        :param T identity: the identity value for the accumulating function - if not specified it will be the first element of the stream</span>
-<span class="sd">        :param Accumulator accumulator: function for combining two values</span>
-<span class="sd">        :return: the result of reduction</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">result</span> <span class="o">=</span> <span class="n">identity</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">result</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">):</span>
-                <span class="n">result</span> <span class="o">=</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="n">result</span> <span class="o">=</span> <span class="n">accumulator</span><span class="p">(</span><span class="n">result</span><span class="p">,</span> <span class="n">elem</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="n">result</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.</p>
-
+    :param Consumer consumer: action to perform on the elements as they are consumed from the stream
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.peek(self.iterable, consumer)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.reduce"><code class="name flex">
+<span>def <span class="ident">reduce</span></span>(<span>self, accumulator, identity=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.</p>
 <p>:param T identity: the identity value for the accumulating function - if not specified it will be the first element of the stream
 :param Accumulator accumulator: function for combining two values
-:return: the result of reduction</p>
+:return: the result of reduction</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def reduce(self, accumulator, identity=None):
+    &#39;&#39;&#39;
+    Performs a reduction on the elements of this stream, using the provided identity value and an associative accumulation function, and returns the reduced value.
+
+    :param T identity: the identity value for the accumulating function - if not specified it will be the first element of the stream
+    :param Accumulator accumulator: function for combining two values
+    :return: the result of reduction
+    &#39;&#39;&#39;
+    result = identity
+    for elem in self.iterable:
+        if(result is None):
+            result = elem
+        else:
+            result = accumulator(result, elem)
+    return Optional.ofNullable(result)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.skip"><code class="name flex">
+<span>def <span class="ident">skip</span></span>(<span>self, count)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.</p>
+<p>:param int count:
+the number of leading elements to skip
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def skip(self, count):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the remaining elements of this stream after discarding the first n elements of the stream. If this stream contains fewer than n elements then an empty stream will be returned.
+
+    :param int count:  the number of leading elements to skip
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.skip(self.iterable, count)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.sorted"><code class="name flex">
+<span>def <span class="ident">sorted</span></span>(<span>self, comparator=None)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.</p>
+<p>:param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sorted(self, comparator=None):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the elements of this stream, sorted according to the provided Comparator.
+
+    :param Comparator comparator: Comparator to be used to compare stream elements - if null default comparator is used
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = iter(sorted(
+        self.iterable, key=cmp_to_key(comparator))) if comparator is not None else iter(sorted(
+            self.iterable))
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.sum"><code class="name flex">
+<span>def <span class="ident">sum</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the sum of all elements of this stream. This is a special case of a reduction.</p>
+<p>:return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def sum(self):
+    &#39;&#39;&#39;
+    Returns the sum of all elements of this stream. This is a special case of a reduction.
+
+    :return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty
+    &#39;&#39;&#39;
+    return self.reduce(lambda x, y: x + y)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.takeWhile"><code class="name flex">
+<span>def <span class="ident">takeWhile</span></span>(<span>self, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.</p>
+<p>:param Predicate predicate:
+predicate to apply to elements to determine the longest prefix of elements.
+:return: self</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def takeWhile(self, predicate):
+    &#39;&#39;&#39;
+    Returns a stream consisting of the longest prefix of elements taken from this stream that match the given predicate.
+
+    :param Predicate predicate:  predicate to apply to elements to determine the longest prefix of elements.
+    :return: self
+    &#39;&#39;&#39;
+    self.iterable = IteratorUtils.takeWhile(self.iterable, predicate)
+    return self</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.toBooleanStream"><code class="name flex">
+<span>def <span class="ident">toBooleanStream</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def toBooleanStream(self):
+    from .booleans import BooleanStream
+    return BooleanStream(self)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.toList"><code class="name flex">
+<span>def <span class="ident">toList</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a list with the elements in this stream.</p>
+<p>:return: the list of elements in this stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def toList(self):
+    &#39;&#39;&#39;
+    Returns a list with the elements in this stream.
+
+    :return: the list of elements in this stream
+    &#39;&#39;&#39;
+    return list(self.iterable)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.toNumberStream"><code class="name flex">
+<span>def <span class="ident">toNumberStream</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def toNumberStream(self):
+    from .numbers import NumberStream
+    return NumberStream(self)</code></pre>
+</details>
+</dd>
+<dt id="stream.stream.Stream.toSet"><code class="name flex">
+<span>def <span class="ident">toSet</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns a set with the elements in this stream.</p>
+<p>:return: the set of elements in this stream</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def toSet(self):
+    &#39;&#39;&#39;
+    Returns a set with the elements in this stream.
+
+    :return: the set of elements in this stream
+    &#39;&#39;&#39;
+    return set(self.iterable)</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
 </div>
-
-
-                            </div>
-                            <div id="Stream.min" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.min">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">min</span><span class="signature">(self, comparator=None)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">min</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used</span>
-<span class="sd">        :return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">elements</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">min</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">),</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">min</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">default</span><span class="o">=</span><span class="kc">None</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns the minimum element of this stream according to the provided Comparator. This is a special case of a reduction.</p>
-
-<p>:param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
-:return: an Optional describing the minimum element of this stream, or an empty Optional if the stream is empty</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.max" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.max">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">max</span><span class="signature">(self, comparator=None)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">max</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">comparator</span><span class="o">=</span><span class="kc">None</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.</span>
-
-<span class="sd">        :param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used</span>
-<span class="sd">        :return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-        <span class="k">if</span> <span class="nb">len</span><span class="p">(</span><span class="n">elements</span><span class="p">)</span> <span class="o">==</span> <span class="mi">0</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">max</span><span class="p">(</span><span class="n">elements</span><span class="p">,</span> <span class="n">key</span><span class="o">=</span><span class="n">cmp_to_key</span><span class="p">(</span><span class="n">comparator</span><span class="p">)))</span> <span class="k">if</span> <span class="n">comparator</span> <span class="ow">is</span> <span class="ow">not</span> <span class="kc">None</span> <span class="k">else</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="nb">max</span><span class="p">(</span><span class="n">elements</span><span class="p">))</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns the maximum element of this stream according to the provided Comparator. This is a special case of a reduction.</p>
-
-<p>:param Comparator comparator: Comparator to compare elements of this stream - if null default comparator is used
-:return: an Optional describing the maximum element of this stream, or an empty Optional if the stream is empty</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.sum" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.sum">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">sum</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">sum</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the sum of all elements of this stream. This is a special case of a reduction.</span>
-
-<span class="sd">        :return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">reduce</span><span class="p">(</span><span class="k">lambda</span> <span class="n">x</span><span class="p">,</span> <span class="n">y</span><span class="p">:</span> <span class="n">x</span> <span class="o">+</span> <span class="n">y</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns the sum of all elements of this stream. This is a special case of a reduction.</p>
-
-<p>:return: an Optional describing the sum of all the elements of this stream, or an empty Optional if the stream is empty</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.count" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.count">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">count</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">count</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns the count of elements in this stream. This is a special case of a reduction.</span>
-
-<span class="sd">        :return: the count of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="n">count</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">:</span>
-            <span class="n">count</span> <span class="o">+=</span> <span class="mi">1</span>
-
-        <span class="k">return</span> <span class="n">count</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns the count of elements in this stream. This is a special case of a reduction.</p>
-
-<p>:return: the count of elements in this stream</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.toList" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.toList">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">toList</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">toList</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a list with the elements in this stream.</span>
-
-<span class="sd">        :return: the list of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">list</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a list with the elements in this stream.</p>
-
-<p>:return: the list of elements in this stream</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.toSet" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.toSet">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">toSet</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">toSet</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns a set with the elements in this stream.</span>
-
-<span class="sd">        :return: the set of elements in this stream</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="nb">set</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">iterable</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns a set with the elements in this stream.</p>
-
-<p>:return: the set of elements in this stream</p>
-</div>
-
-
-                            </div>
-                            <div id="Stream.toNumberStream" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.toNumberStream">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">toNumberStream</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">toNumberStream</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="kn">from</span> <span class="nn">.numbers</span> <span class="kn">import</span> <span class="n">NumberStream</span>
-        <span class="k">return</span> <span class="n">NumberStream</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="Stream.toBooleanStream" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Stream.toBooleanStream">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">toBooleanStream</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">toBooleanStream</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="kn">from</span> <span class="nn">.booleans</span> <span class="kn">import</span> <span class="n">BooleanStream</span>
-        <span class="k">return</span> <span class="n">BooleanStream</span><span class="p">(</span><span class="bp">self</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                </section>
-    </main>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="stream" href="index.html">stream</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="stream.stream.Stream" href="#stream.stream.Stream">Stream</a></code></h4>
+<ul class="two-column">
+<li><code><a title="stream.stream.Stream.allMatch" href="#stream.stream.Stream.allMatch">allMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.anyMatch" href="#stream.stream.Stream.anyMatch">anyMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.concat" href="#stream.stream.Stream.concat">concat</a></code></li>
+<li><code><a title="stream.stream.Stream.constant" href="#stream.stream.Stream.constant">constant</a></code></li>
+<li><code><a title="stream.stream.Stream.count" href="#stream.stream.Stream.count">count</a></code></li>
+<li><code><a title="stream.stream.Stream.distinct" href="#stream.stream.Stream.distinct">distinct</a></code></li>
+<li><code><a title="stream.stream.Stream.dropWhile" href="#stream.stream.Stream.dropWhile">dropWhile</a></code></li>
+<li><code><a title="stream.stream.Stream.empty" href="#stream.stream.Stream.empty">empty</a></code></li>
+<li><code><a title="stream.stream.Stream.filter" href="#stream.stream.Stream.filter">filter</a></code></li>
+<li><code><a title="stream.stream.Stream.findAny" href="#stream.stream.Stream.findAny">findAny</a></code></li>
+<li><code><a title="stream.stream.Stream.findFirst" href="#stream.stream.Stream.findFirst">findFirst</a></code></li>
+<li><code><a title="stream.stream.Stream.flatMap" href="#stream.stream.Stream.flatMap">flatMap</a></code></li>
+<li><code><a title="stream.stream.Stream.forEach" href="#stream.stream.Stream.forEach">forEach</a></code></li>
+<li><code><a title="stream.stream.Stream.generate" href="#stream.stream.Stream.generate">generate</a></code></li>
+<li><code><a title="stream.stream.Stream.iterate" href="#stream.stream.Stream.iterate">iterate</a></code></li>
+<li><code><a title="stream.stream.Stream.limit" href="#stream.stream.Stream.limit">limit</a></code></li>
+<li><code><a title="stream.stream.Stream.map" href="#stream.stream.Stream.map">map</a></code></li>
+<li><code><a title="stream.stream.Stream.max" href="#stream.stream.Stream.max">max</a></code></li>
+<li><code><a title="stream.stream.Stream.min" href="#stream.stream.Stream.min">min</a></code></li>
+<li><code><a title="stream.stream.Stream.noneMatch" href="#stream.stream.Stream.noneMatch">noneMatch</a></code></li>
+<li><code><a title="stream.stream.Stream.of" href="#stream.stream.Stream.of">of</a></code></li>
+<li><code><a title="stream.stream.Stream.ofNullable" href="#stream.stream.Stream.ofNullable">ofNullable</a></code></li>
+<li><code><a title="stream.stream.Stream.peek" href="#stream.stream.Stream.peek">peek</a></code></li>
+<li><code><a title="stream.stream.Stream.reduce" href="#stream.stream.Stream.reduce">reduce</a></code></li>
+<li><code><a title="stream.stream.Stream.skip" href="#stream.stream.Stream.skip">skip</a></code></li>
+<li><code><a title="stream.stream.Stream.sorted" href="#stream.stream.Stream.sorted">sorted</a></code></li>
+<li><code><a title="stream.stream.Stream.sum" href="#stream.stream.Stream.sum">sum</a></code></li>
+<li><code><a title="stream.stream.Stream.takeWhile" href="#stream.stream.Stream.takeWhile">takeWhile</a></code></li>
+<li><code><a title="stream.stream.Stream.toBooleanStream" href="#stream.stream.Stream.toBooleanStream">toBooleanStream</a></code></li>
+<li><code><a title="stream.stream.Stream.toList" href="#stream.stream.Stream.toList">toList</a></code></li>
+<li><code><a title="stream.stream.Stream.toNumberStream" href="#stream.stream.Stream.toNumberStream">toNumberStream</a></code></li>
+<li><code><a title="stream.stream.Stream.toSet" href="#stream.stream.Stream.toSet">toSet</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
 </body>
 </html>

--- a/doc/stream/util/index.html
+++ b/doc/stream/util/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>stream.util API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>stream.util</code></h1>
+</header>
+<section id="section-intro">
+</section>
+<section>
+<h2 class="section-title" id="header-submodules">Sub-modules</h2>
+<dl>
+<dt><code class="name"><a title="stream.util.iterators" href="iterators.html">stream.util.iterators</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+<dt><code class="name"><a title="stream.util.optional" href="optional.html">stream.util.optional</a></code></dt>
+<dd>
+<div class="desc"></div>
+</dd>
+</dl>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="stream" href="../index.html">stream</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-submodules">Sub-modules</a></h3>
+<ul>
+<li><code><a title="stream.util.iterators" href="iterators.html">stream.util.iterators</a></code></li>
+<li><code><a title="stream.util.optional" href="optional.html">stream.util.optional</a></code></li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
+</body>
+</html>

--- a/doc/stream/util/iterators.html
+++ b/doc/stream/util/iterators.html
@@ -1,605 +1,487 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="generator" content="pdoc 6.3.2" />
-    <title>stream.util.iterators API documentation</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
-
-
-<style type="text/css">/*! * Bootstrap Reboot v5.0.0-beta1 (https://getbootstrap.com/) * Copyright 2011-2020 The Bootstrap Authors * Copyright 2011-2020 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}[tabindex="-1"]:focus:not(:focus-visible){outline:0!important}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{text-decoration:underline;-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus{outline:dotted 1px;outline:-webkit-focus-ring-color auto 5px}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
-<style type="text/css">/*! pygments syntax highlighting */pre{line-height:125%;}td.linenos pre{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}span.linenos{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}td.linenos pre.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}span.linenos.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}.pdoc .hll{background-color:#ffffcc}.pdoc{background:#f8f8f8;}.pdoc .c{color:#408080; font-style:italic}.pdoc .err{border:1px solid #FF0000}.pdoc .k{color:#008000; font-weight:bold}.pdoc .o{color:#666666}.pdoc .ch{color:#408080; font-style:italic}.pdoc .cm{color:#408080; font-style:italic}.pdoc .cp{color:#BC7A00}.pdoc .cpf{color:#408080; font-style:italic}.pdoc .c1{color:#408080; font-style:italic}.pdoc .cs{color:#408080; font-style:italic}.pdoc .gd{color:#A00000}.pdoc .ge{font-style:italic}.pdoc .gr{color:#FF0000}.pdoc .gh{color:#000080; font-weight:bold}.pdoc .gi{color:#00A000}.pdoc .go{color:#888888}.pdoc .gp{color:#000080; font-weight:bold}.pdoc .gs{font-weight:bold}.pdoc .gu{color:#800080; font-weight:bold}.pdoc .gt{color:#0044DD}.pdoc .kc{color:#008000; font-weight:bold}.pdoc .kd{color:#008000; font-weight:bold}.pdoc .kn{color:#008000; font-weight:bold}.pdoc .kp{color:#008000}.pdoc .kr{color:#008000; font-weight:bold}.pdoc .kt{color:#B00040}.pdoc .m{color:#666666}.pdoc .s{color:#BA2121}.pdoc .na{color:#7D9029}.pdoc .nb{color:#008000}.pdoc .nc{color:#0000FF; font-weight:bold}.pdoc .no{color:#880000}.pdoc .nd{color:#AA22FF}.pdoc .ni{color:#999999; font-weight:bold}.pdoc .ne{color:#D2413A; font-weight:bold}.pdoc .nf{color:#0000FF}.pdoc .nl{color:#A0A000}.pdoc .nn{color:#0000FF; font-weight:bold}.pdoc .nt{color:#008000; font-weight:bold}.pdoc .nv{color:#19177C}.pdoc .ow{color:#AA22FF; font-weight:bold}.pdoc .w{color:#bbbbbb}.pdoc .mb{color:#666666}.pdoc .mf{color:#666666}.pdoc .mh{color:#666666}.pdoc .mi{color:#666666}.pdoc .mo{color:#666666}.pdoc .sa{color:#BA2121}.pdoc .sb{color:#BA2121}.pdoc .sc{color:#BA2121}.pdoc .dl{color:#BA2121}.pdoc .sd{color:#BA2121; font-style:italic}.pdoc .s2{color:#BA2121}.pdoc .se{color:#BB6622; font-weight:bold}.pdoc .sh{color:#BA2121}.pdoc .si{color:#BB6688; font-weight:bold}.pdoc .sx{color:#008000}.pdoc .sr{color:#BB6688}.pdoc .s1{color:#BA2121}.pdoc .ss{color:#19177C}.pdoc .bp{color:#008000}.pdoc .fm{color:#0000FF}.pdoc .vc{color:#19177C}.pdoc .vg{color:#19177C}.pdoc .vi{color:#19177C}.pdoc .vm{color:#19177C}.pdoc .il{color:#666666}</style>
-<style type="text/css">/*! pdoc */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f7f7f7;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}body{background-color:var(--pdoc-background);}html, body{width:100%;height:100%;}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main{padding:2rem 3vw;}.git-button{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}#navtoggle{display:none;}}#togglestate{display:none;}nav.pdoc{--pad:1.75rem;--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc li{display:block;margin:0;padding:.2rem 0 .2rem var(--indent);transition:all 100ms;}nav.pdoc > div > ul > li{padding-left:0;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}html, main{scroll-behavior:smooth;}.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3, .pdoc h4{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{background-color:var(--code);border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.pdoc details{--shift:-40px;text-align:right;margin-top:var(--shift);margin-bottom:calc(0px - var(--shift));clear:both;filter:opacity(1);}.pdoc details:not([open]){height:0;overflow:visible;}.pdoc details > summary{font-size:.75rem;cursor:pointer;color:var(--muted);border-width:0;padding:0 .7em;display:inline-block;display:inline list-item;user-select:none;}.pdoc details > summary:focus{outline:0;}.pdoc details > div{margin-top:calc(0px - var(--shift) / 2);text-align:left;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc > section:first-of-type > .docstring{margin-bottom:3rem;}.pdoc .docstring pre{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc .headerlink{position:absolute;width:0;margin-left:-1.5rem;line-height:1.4rem;font-size:1.5rem;font-weight:normal;transition:all 100ms ease-in-out;opacity:0;}.pdoc .attr > .headerlink{margin-left:-2.5rem;}.pdoc *:hover > .headerlink,.pdoc *:target > .attr > .headerlink{opacity:1;}.pdoc .attr{color:var(--text);margin:1rem 0 .5rem;padding:.4rem 5rem .4rem 1rem;background-color:var(--accent);}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{white-space:pre-wrap;}.pdoc .annotation{color:var(--annotation);}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}</style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>stream.util.iterators API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
-<body>        <nav class="pdoc">
-            <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
-            <input id="togglestate" type="checkbox">
-            <div>
-                        <a class="pdoc-button module-list-button" href="../util.html">
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-in-left" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M10 3.5a.5.5 0 0 0-.5-.5h-8a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-2a.5.5 0 0 1 1 0v2A1.5 1.5 0 0 1 9.5 14h-8A1.5 1.5 0 0 1 0 12.5v-9A1.5 1.5 0 0 1 1.5 2h8A1.5 1.5 0 0 1 11 3.5v2a.5.5 0 0 1-1 0v-2z"/>
-  <path fill-rule="evenodd" d="M4.146 8.354a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H14.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3z"/>
-</svg>                            &nbsp;stream.util</a>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>stream.util.iterators</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class IteratorUtils:
 
+    &#34;&#34;&#34;
+    Iterator Utils
+    &#34;&#34;&#34;
 
+    &#34;&#34;&#34;
+    Methods for Static Method of Stream
+    &#34;&#34;&#34;
+    @staticmethod
+    def iterate(seed, operator):
+        while(True):
+            yield seed
+            seed = operator(seed)
 
+    @staticmethod
+    def generate(generator):
+        while(True):
+            yield generator()
 
-                    <h2>API Documentation</h2>
-                        <ul class="memberlist">
-            <li>
-                    <a class="class" href="#IteratorUtils">IteratorUtils</a>
-                            <ul class="memberlist">
-                        <li>
-                                <a class="function" href="#IteratorUtils.__init__">IteratorUtils</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.iterate">iterate</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.generate">generate</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.concat">concat</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.filter">filter</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.map">map</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.flatMap">flatMap</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.distinct">distinct</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.peek">peek</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.takeWhile">takeWhile</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.dropWhile">dropWhile</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.skip">skip</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#IteratorUtils.limit">limit</a>
-                        </li>
-                </ul>
+    @staticmethod
+    def concat(*iterables):
+        for iterable in iterables:
+            for elem in iterable:
+                yield elem
 
-            </li>
-    </ul>
+    &#34;&#34;&#34;
+    Methods for Normal Method of Stream
+    &#34;&#34;&#34;
+    @staticmethod
+    def filter(iterable, predicate):
+        for elem in iterable:
+            if(predicate(elem)):
+                yield elem
 
+    @staticmethod
+    def map(iterable, mapper):
+        for elem in iterable:
+            yield mapper(elem)
 
-                    <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev">
-                        built with <span class="visually-hidden">pdoc</span><img
-                            alt="pdoc logo"
-                            src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
-                    </a>
-            </div>
-        </nav>
-    <main class="pdoc">
-            <section>
-                    <h1 class="modulename">
-<a href="./../../stream.html">stream</a>.<a href="./../util.html">util</a>.iterators    </h1>
+    @staticmethod
+    def flatMap(iterable, mapper):
+        for elem in iterable:
+            for internal in mapper(elem):
+                yield internal
 
-                
-                        <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">IteratorUtils</span><span class="p">:</span>
+    @staticmethod
+    def distinct(iterable):
+        elements = set()
+        for elem in iterable:
+            if elem not in elements:
+                elements.add(elem)
+                yield elem
 
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Iterator Utils</span>
-<span class="sd">    &quot;&quot;&quot;</span>
+    @staticmethod
+    def peek(iterable, function):
+        for elem in iterable:
+            function(elem)
+            yield elem
 
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Methods for Static Method of Stream</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">):</span>
-        <span class="k">while</span><span class="p">(</span><span class="kc">True</span><span class="p">):</span>
-            <span class="k">yield</span> <span class="n">seed</span>
-            <span class="n">seed</span> <span class="o">=</span> <span class="n">operator</span><span class="p">(</span><span class="n">seed</span><span class="p">)</span>
+    @staticmethod
+    def takeWhile(iterable, predicate):
+        for elem in iterable:
+            if(predicate(elem)):
+                yield elem
+            else:
+                break
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">generate</span><span class="p">(</span><span class="n">generator</span><span class="p">):</span>
-        <span class="k">while</span><span class="p">(</span><span class="kc">True</span><span class="p">):</span>
-            <span class="k">yield</span> <span class="n">generator</span><span class="p">()</span>
+    @staticmethod
+    def dropWhile(iterable, predicate):
+        toDrop = True
+        for elem in iterable:
+            if(not predicate(elem) and toDrop):
+                toDrop = False
+            if(not toDrop):
+                yield elem
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">concat</span><span class="p">(</span><span class="o">*</span><span class="n">iterables</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">iterable</span> <span class="ow">in</span> <span class="n">iterables</span><span class="p">:</span>
-            <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-                <span class="k">yield</span> <span class="n">elem</span>
+    @staticmethod
+    def skip(iterable, count):
+        index = 0
+        for elem in iterable:
+            index += 1
+            if(index &gt; count):
+                yield elem
 
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Methods for Normal Method of Stream</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
+    @staticmethod
+    def limit(iterable, count):
+        index = 0
+        for elem in iterable:
+            index += 1
+            if(index &lt;= count):
+                yield elem
+            else:
+                break</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="stream.util.iterators.IteratorUtils"><code class="flex name class">
+<span>class <span class="ident">IteratorUtils</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Iterator Utils</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class IteratorUtils:
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">yield</span> <span class="n">mapper</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
+    &#34;&#34;&#34;
+    Iterator Utils
+    &#34;&#34;&#34;
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">flatMap</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">for</span> <span class="n">internal</span> <span class="ow">in</span> <span class="n">mapper</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">internal</span>
+    &#34;&#34;&#34;
+    Methods for Static Method of Stream
+    &#34;&#34;&#34;
+    @staticmethod
+    def iterate(seed, operator):
+        while(True):
+            yield seed
+            seed = operator(seed)
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">distinct</span><span class="p">(</span><span class="n">iterable</span><span class="p">):</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">set</span><span class="p">()</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span> <span class="n">elem</span> <span class="ow">not</span> <span class="ow">in</span> <span class="n">elements</span><span class="p">:</span>
-                <span class="n">elements</span><span class="o">.</span><span class="n">add</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-                <span class="k">yield</span> <span class="n">elem</span>
+    @staticmethod
+    def generate(generator):
+        while(True):
+            yield generator()
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">peek</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">function</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">function</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-            <span class="k">yield</span> <span class="n">elem</span>
+    @staticmethod
+    def concat(*iterables):
+        for iterable in iterables:
+            for elem in iterable:
+                yield elem
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">takeWhile</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">break</span>
+    &#34;&#34;&#34;
+    Methods for Normal Method of Stream
+    &#34;&#34;&#34;
+    @staticmethod
+    def filter(iterable, predicate):
+        for elem in iterable:
+            if(predicate(elem)):
+                yield elem
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">dropWhile</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="n">toDrop</span> <span class="o">=</span> <span class="kc">True</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="ow">not</span> <span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="ow">and</span> <span class="n">toDrop</span><span class="p">):</span>
-                <span class="n">toDrop</span> <span class="o">=</span> <span class="kc">False</span>
-            <span class="k">if</span><span class="p">(</span><span class="ow">not</span> <span class="n">toDrop</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
+    @staticmethod
+    def map(iterable, mapper):
+        for elem in iterable:
+            yield mapper(elem)
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">skip</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="n">index</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">index</span> <span class="o">+=</span> <span class="mi">1</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">index</span> <span class="o">&gt;</span> <span class="n">count</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
+    @staticmethod
+    def flatMap(iterable, mapper):
+        for elem in iterable:
+            for internal in mapper(elem):
+                yield internal
 
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">limit</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="n">index</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">index</span> <span class="o">+=</span> <span class="mi">1</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">index</span> <span class="o">&lt;=</span> <span class="n">count</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">break</span>
-</pre></div>
+    @staticmethod
+    def distinct(iterable):
+        elements = set()
+        for elem in iterable:
+            if elem not in elements:
+                elements.add(elem)
+                yield elem
 
-        </details>
+    @staticmethod
+    def peek(iterable, function):
+        for elem in iterable:
+            function(elem)
+            yield elem
 
-            </section>
-                <section id="IteratorUtils">
-                                <div class="attr class">
-        <a class="headerlink" href="#IteratorUtils">#&nbsp;&nbsp</a>
+    @staticmethod
+    def takeWhile(iterable, predicate):
+        for elem in iterable:
+            if(predicate(elem)):
+                yield elem
+            else:
+                break
 
-        
-        <span class="def">class</span>
-        <span class="name">IteratorUtils</span>:
-    </div>
+    @staticmethod
+    def dropWhile(iterable, predicate):
+        toDrop = True
+        for elem in iterable:
+            if(not predicate(elem) and toDrop):
+                toDrop = False
+            if(not toDrop):
+                yield elem
 
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">IteratorUtils</span><span class="p">:</span>
+    @staticmethod
+    def skip(iterable, count):
+        index = 0
+        for elem in iterable:
+            index += 1
+            if(index &gt; count):
+                yield elem
 
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Iterator Utils</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Methods for Static Method of Stream</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">):</span>
-        <span class="k">while</span><span class="p">(</span><span class="kc">True</span><span class="p">):</span>
-            <span class="k">yield</span> <span class="n">seed</span>
-            <span class="n">seed</span> <span class="o">=</span> <span class="n">operator</span><span class="p">(</span><span class="n">seed</span><span class="p">)</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">generate</span><span class="p">(</span><span class="n">generator</span><span class="p">):</span>
-        <span class="k">while</span><span class="p">(</span><span class="kc">True</span><span class="p">):</span>
-            <span class="k">yield</span> <span class="n">generator</span><span class="p">()</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">concat</span><span class="p">(</span><span class="o">*</span><span class="n">iterables</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">iterable</span> <span class="ow">in</span> <span class="n">iterables</span><span class="p">:</span>
-            <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-
-    <span class="sd">&quot;&quot;&quot;</span>
-<span class="sd">    Methods for Normal Method of Stream</span>
-<span class="sd">    &quot;&quot;&quot;</span>
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">yield</span> <span class="n">mapper</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">flatMap</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">for</span> <span class="n">internal</span> <span class="ow">in</span> <span class="n">mapper</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">internal</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">distinct</span><span class="p">(</span><span class="n">iterable</span><span class="p">):</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">set</span><span class="p">()</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span> <span class="n">elem</span> <span class="ow">not</span> <span class="ow">in</span> <span class="n">elements</span><span class="p">:</span>
-                <span class="n">elements</span><span class="o">.</span><span class="n">add</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">peek</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">function</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">function</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-            <span class="k">yield</span> <span class="n">elem</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">takeWhile</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">break</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">dropWhile</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="n">toDrop</span> <span class="o">=</span> <span class="kc">True</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="ow">not</span> <span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="ow">and</span> <span class="n">toDrop</span><span class="p">):</span>
-                <span class="n">toDrop</span> <span class="o">=</span> <span class="kc">False</span>
-            <span class="k">if</span><span class="p">(</span><span class="ow">not</span> <span class="n">toDrop</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">skip</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="n">index</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">index</span> <span class="o">+=</span> <span class="mi">1</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">index</span> <span class="o">&gt;</span> <span class="n">count</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">limit</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="n">index</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">index</span> <span class="o">+=</span> <span class="mi">1</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">index</span> <span class="o">&lt;=</span> <span class="n">count</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">break</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Iterator Utils</p>
+    @staticmethod
+    def limit(iterable, count):
+        index = 0
+        for elem in iterable:
+            index += 1
+            if(index &lt;= count):
+                yield elem
+            else:
+                break</code></pre>
+</details>
+<h3>Static methods</h3>
+<dl>
+<dt id="stream.util.iterators.IteratorUtils.concat"><code class="name flex">
+<span>def <span class="ident">concat</span></span>(<span>*iterables)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def concat(*iterables):
+    for iterable in iterables:
+        for elem in iterable:
+            yield elem</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.distinct"><code class="name flex">
+<span>def <span class="ident">distinct</span></span>(<span>iterable)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def distinct(iterable):
+    elements = set()
+    for elem in iterable:
+        if elem not in elements:
+            elements.add(elem)
+            yield elem</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.dropWhile"><code class="name flex">
+<span>def <span class="ident">dropWhile</span></span>(<span>iterable, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def dropWhile(iterable, predicate):
+    toDrop = True
+    for elem in iterable:
+        if(not predicate(elem) and toDrop):
+            toDrop = False
+        if(not toDrop):
+            yield elem</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.filter"><code class="name flex">
+<span>def <span class="ident">filter</span></span>(<span>iterable, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def filter(iterable, predicate):
+    for elem in iterable:
+        if(predicate(elem)):
+            yield elem</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.flatMap"><code class="name flex">
+<span>def <span class="ident">flatMap</span></span>(<span>iterable, mapper)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def flatMap(iterable, mapper):
+    for elem in iterable:
+        for internal in mapper(elem):
+            yield internal</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.generate"><code class="name flex">
+<span>def <span class="ident">generate</span></span>(<span>generator)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def generate(generator):
+    while(True):
+        yield generator()</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.iterate"><code class="name flex">
+<span>def <span class="ident">iterate</span></span>(<span>seed, operator)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def iterate(seed, operator):
+    while(True):
+        yield seed
+        seed = operator(seed)</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.limit"><code class="name flex">
+<span>def <span class="ident">limit</span></span>(<span>iterable, count)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def limit(iterable, count):
+    index = 0
+    for elem in iterable:
+        index += 1
+        if(index &lt;= count):
+            yield elem
+        else:
+            break</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.map"><code class="name flex">
+<span>def <span class="ident">map</span></span>(<span>iterable, mapper)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def map(iterable, mapper):
+    for elem in iterable:
+        yield mapper(elem)</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.peek"><code class="name flex">
+<span>def <span class="ident">peek</span></span>(<span>iterable, function)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def peek(iterable, function):
+    for elem in iterable:
+        function(elem)
+        yield elem</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.skip"><code class="name flex">
+<span>def <span class="ident">skip</span></span>(<span>iterable, count)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def skip(iterable, count):
+    index = 0
+    for elem in iterable:
+        index += 1
+        if(index &gt; count):
+            yield elem</code></pre>
+</details>
+</dd>
+<dt id="stream.util.iterators.IteratorUtils.takeWhile"><code class="name flex">
+<span>def <span class="ident">takeWhile</span></span>(<span>iterable, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def takeWhile(iterable, predicate):
+    for elem in iterable:
+        if(predicate(elem)):
+            yield elem
+        else:
+            break</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
 </div>
-
-
-                            <div id="IteratorUtils.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.__init__">#&nbsp;&nbsp</a>
-
-        
-            <span class="name">IteratorUtils</span><span class="signature">()</span>    </div>
-
-        
-    
-
-                            </div>
-                            <div id="IteratorUtils.iterate" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.iterate">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">iterate</span><span class="signature">(seed, operator)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">iterate</span><span class="p">(</span><span class="n">seed</span><span class="p">,</span> <span class="n">operator</span><span class="p">):</span>
-        <span class="k">while</span><span class="p">(</span><span class="kc">True</span><span class="p">):</span>
-            <span class="k">yield</span> <span class="n">seed</span>
-            <span class="n">seed</span> <span class="o">=</span> <span class="n">operator</span><span class="p">(</span><span class="n">seed</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.generate" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.generate">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">generate</span><span class="signature">(generator)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">generate</span><span class="p">(</span><span class="n">generator</span><span class="p">):</span>
-        <span class="k">while</span><span class="p">(</span><span class="kc">True</span><span class="p">):</span>
-            <span class="k">yield</span> <span class="n">generator</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.concat" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.concat">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">concat</span><span class="signature">(*iterables)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">concat</span><span class="p">(</span><span class="o">*</span><span class="n">iterables</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">iterable</span> <span class="ow">in</span> <span class="n">iterables</span><span class="p">:</span>
-            <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.filter" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.filter">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">filter</span><span class="signature">(iterable, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.map" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.map">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">map</span><span class="signature">(iterable, mapper)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">yield</span> <span class="n">mapper</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.flatMap" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.flatMap">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">flatMap</span><span class="signature">(iterable, mapper)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">flatMap</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">for</span> <span class="n">internal</span> <span class="ow">in</span> <span class="n">mapper</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">internal</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.distinct" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.distinct">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">distinct</span><span class="signature">(iterable)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">distinct</span><span class="p">(</span><span class="n">iterable</span><span class="p">):</span>
-        <span class="n">elements</span> <span class="o">=</span> <span class="nb">set</span><span class="p">()</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span> <span class="n">elem</span> <span class="ow">not</span> <span class="ow">in</span> <span class="n">elements</span><span class="p">:</span>
-                <span class="n">elements</span><span class="o">.</span><span class="n">add</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.peek" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.peek">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">peek</span><span class="signature">(iterable, function)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">peek</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">function</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">function</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-            <span class="k">yield</span> <span class="n">elem</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.takeWhile" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.takeWhile">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">takeWhile</span><span class="signature">(iterable, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">takeWhile</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">break</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.dropWhile" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.dropWhile">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">dropWhile</span><span class="signature">(iterable, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">dropWhile</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="n">toDrop</span> <span class="o">=</span> <span class="kc">True</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="k">if</span><span class="p">(</span><span class="ow">not</span> <span class="n">predicate</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span> <span class="ow">and</span> <span class="n">toDrop</span><span class="p">):</span>
-                <span class="n">toDrop</span> <span class="o">=</span> <span class="kc">False</span>
-            <span class="k">if</span><span class="p">(</span><span class="ow">not</span> <span class="n">toDrop</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.skip" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.skip">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">skip</span><span class="signature">(iterable, count)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">skip</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="n">index</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">index</span> <span class="o">+=</span> <span class="mi">1</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">index</span> <span class="o">&gt;</span> <span class="n">count</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="IteratorUtils.limit" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#IteratorUtils.limit">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">limit</span><span class="signature">(iterable, count)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">limit</span><span class="p">(</span><span class="n">iterable</span><span class="p">,</span> <span class="n">count</span><span class="p">):</span>
-        <span class="n">index</span> <span class="o">=</span> <span class="mi">0</span>
-        <span class="k">for</span> <span class="n">elem</span> <span class="ow">in</span> <span class="n">iterable</span><span class="p">:</span>
-            <span class="n">index</span> <span class="o">+=</span> <span class="mi">1</span>
-            <span class="k">if</span><span class="p">(</span><span class="n">index</span> <span class="o">&lt;=</span> <span class="n">count</span><span class="p">):</span>
-                <span class="k">yield</span> <span class="n">elem</span>
-            <span class="k">else</span><span class="p">:</span>
-                <span class="k">break</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                </section>
-    </main>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="stream.util" href="index.html">stream.util</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="stream.util.iterators.IteratorUtils" href="#stream.util.iterators.IteratorUtils">IteratorUtils</a></code></h4>
+<ul class="two-column">
+<li><code><a title="stream.util.iterators.IteratorUtils.concat" href="#stream.util.iterators.IteratorUtils.concat">concat</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.distinct" href="#stream.util.iterators.IteratorUtils.distinct">distinct</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.dropWhile" href="#stream.util.iterators.IteratorUtils.dropWhile">dropWhile</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.filter" href="#stream.util.iterators.IteratorUtils.filter">filter</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.flatMap" href="#stream.util.iterators.IteratorUtils.flatMap">flatMap</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.generate" href="#stream.util.iterators.IteratorUtils.generate">generate</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.iterate" href="#stream.util.iterators.IteratorUtils.iterate">iterate</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.limit" href="#stream.util.iterators.IteratorUtils.limit">limit</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.map" href="#stream.util.iterators.IteratorUtils.map">map</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.peek" href="#stream.util.iterators.IteratorUtils.peek">peek</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.skip" href="#stream.util.iterators.IteratorUtils.skip">skip</a></code></li>
+<li><code><a title="stream.util.iterators.IteratorUtils.takeWhile" href="#stream.util.iterators.IteratorUtils.takeWhile">takeWhile</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
 </body>
 </html>

--- a/doc/stream/util/optional.html
+++ b/doc/stream/util/optional.html
@@ -1,703 +1,648 @@
 <!doctype html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="generator" content="pdoc 6.3.2" />
-    <title>stream.util.optional API documentation</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20width%3D%2264%22%20height%3D%2264%22%20viewBox%3D%2244.5%202.5%2015%2015%22%3E%3Cpath%20d%3D%22M49.351%2021.041c-.233-.721-.546-2.408-.772-4.076-.042-.09-.067-.187-.046-.288-.166-1.347-.277-2.625-.241-3.351-1.378-1.008-2.271-2.586-2.271-4.362%200-.976.272-1.935.788-2.774.057-.094.122-.18.184-.268-.033-.167-.052-.339-.052-.516%200-1.477%201.202-2.679%202.679-2.679.791%200%201.496.352%201.987.9a6.3%206.3%200%200%201%201.001.029c.492-.564%201.207-.929%202.012-.929%201.477%200%202.679%201.202%202.679%202.679a2.65%202.65%200%200%201-.269%201.148c.383.747.595%201.572.595%202.41%200%202.311-1.507%204.29-3.635%205.107.037.699.147%202.27.423%203.294l.137.461c.156%202.136-4.612%205.166-5.199%203.215zm.127-4.919a4.78%204.78%200%200%200%20.775-.584c-.172-.115-.505-.254-.88-.378zm.331%202.302l.828-.502c-.202-.143-.576-.328-.984-.49zm.45%202.157l.701-.403c-.214-.115-.536-.249-.891-.376l.19.779zM49.13%204.141c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm.735-.389a1.15%201.15%200%200%201%20.314.783%201.16%201.16%200%200%201-1.162%201.162c-.457%200-.842-.27-1.032-.653-.026.117-.042.238-.042.362a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.843-.626-1.535-1.436-1.654zm3.076%201.654a1.68%201.68%200%200%200%201.679%201.679%201.68%201.68%200%200%200%201.679-1.679c0-.037-.009-.072-.011-.109-.21.3-.541.508-.935.508a1.16%201.16%200%200%201-1.162-1.162%201.14%201.14%200%200%201%20.474-.912c-.015%200-.03-.005-.045-.005-.926.001-1.679.754-1.679%201.68zm1.861-1.265c0%20.152.123.276.276.276s.275-.124.275-.276-.123-.276-.276-.276-.275.124-.275.276zm1.823%204.823c0-.52-.103-1.035-.288-1.52-.466.394-1.06.64-1.717.64-1.144%200-2.116-.725-2.499-1.738-.383%201.012-1.355%201.738-2.499%201.738-.867%200-1.631-.421-2.121-1.062-.307.605-.478%201.267-.478%201.942%200%202.486%202.153%204.51%204.801%204.51s4.801-2.023%204.801-4.51zm-3.032%209.156l-.146-.492c-.276-1.02-.395-2.457-.444-3.268a6.11%206.11%200%200%201-1.18.115%206.01%206.01%200%200%201-2.536-.562l.006.175c.802.215%201.848.612%202.021%201.25.079.295-.021.601-.274.837l-.598.501c.667.304%201.243.698%201.311%201.179.02.144.022.507-.393.787l-.564.365c1.285.521%201.361.96%201.381%201.126.018.142.011.496-.427.746l-.854.489c.064-1.19%201.985-2.585%202.697-3.248zM49.34%209.925c0-.667%201-.667%201%200%200%20.653.818%201.205%201.787%201.205s1.787-.552%201.787-1.205c0-.667%201-.667%201%200%200%201.216-1.25%202.205-2.787%202.205s-2.787-.989-2.787-2.205zm-.887-7.633c-.093.077-.205.114-.317.114a.5.5%200%200%201-.318-.886L49.183.397a.5.5%200%200%201%20.703.068.5.5%200%200%201-.069.703zm7.661-.065c-.086%200-.173-.022-.253-.068l-1.523-.893c-.575-.337-.069-1.2.506-.863l1.523.892a.5.5%200%200%201%20.179.685c-.094.158-.261.247-.432.247z%22%20fill%3D%22%233bb300%22/%3E%3C/svg%3E"/>
-
-
-<style type="text/css">/*! * Bootstrap Reboot v5.0.0-beta1 (https://getbootstrap.com/) * Copyright 2011-2020 The Bootstrap Authors * Copyright 2011-2020 Twitter, Inc. * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE) * Forked from Normalize.css, licensed MIT (https://github.com/necolas/normalize.css/blob/master/LICENSE.md) */*,::after,::before{box-sizing:border-box}@media (prefers-reduced-motion:no-preference){:root{scroll-behavior:smooth}}body{margin:0;font-family:system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial,"Noto Sans","Liberation Sans",sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol","Noto Color Emoji";font-size:1rem;font-weight:400;line-height:1.5;color:#212529;background-color:#fff;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:transparent}[tabindex="-1"]:focus:not(:focus-visible){outline:0!important}hr{margin:1rem 0;color:inherit;background-color:currentColor;border:0;opacity:.25}hr:not([size]){height:1px}h1,h2,h3,h4,h5,h6{margin-top:0;margin-bottom:.5rem;font-weight:500;line-height:1.2}h1{font-size:calc(1.375rem + 1.5vw)}@media (min-width:1200px){h1{font-size:2.5rem}}h2{font-size:calc(1.325rem + .9vw)}@media (min-width:1200px){h2{font-size:2rem}}h3{font-size:calc(1.3rem + .6vw)}@media (min-width:1200px){h3{font-size:1.75rem}}h4{font-size:calc(1.275rem + .3vw)}@media (min-width:1200px){h4{font-size:1.5rem}}h5{font-size:1.25rem}h6{font-size:1rem}p{margin-top:0;margin-bottom:1rem}abbr[data-bs-original-title],abbr[title]{text-decoration:underline;-webkit-text-decoration:underline dotted;text-decoration:underline dotted;cursor:help;-webkit-text-decoration-skip-ink:none;text-decoration-skip-ink:none}address{margin-bottom:1rem;font-style:normal;line-height:inherit}ol,ul{padding-left:2rem}dl,ol,ul{margin-top:0;margin-bottom:1rem}ol ol,ol ul,ul ol,ul ul{margin-bottom:0}dt{font-weight:700}dd{margin-bottom:.5rem;margin-left:0}blockquote{margin:0 0 1rem}b,strong{font-weight:bolder}small{font-size:.875em}mark{padding:.2em;background-color:#fcf8e3}sub,sup{position:relative;font-size:.75em;line-height:0;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}a{color:#0d6efd;text-decoration:underline}a:hover{color:#0a58ca}a:not([href]):not([class]),a:not([href]):not([class]):hover{color:inherit;text-decoration:none}code,kbd,pre,samp{font-family:SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;font-size:1em;direction:ltr;unicode-bidi:bidi-override}pre{display:block;margin-top:0;margin-bottom:1rem;overflow:auto;font-size:.875em}pre code{font-size:inherit;color:inherit;word-break:normal}code{font-size:.875em;color:#d63384;word-wrap:break-word}a>code{color:inherit}kbd{padding:.2rem .4rem;font-size:.875em;color:#fff;background-color:#212529;border-radius:.2rem}kbd kbd{padding:0;font-size:1em;font-weight:700}figure{margin:0 0 1rem}img,svg{vertical-align:middle}table{caption-side:bottom;border-collapse:collapse}caption{padding-top:.5rem;padding-bottom:.5rem;color:#6c757d;text-align:left}th{text-align:inherit;text-align:-webkit-match-parent}tbody,td,tfoot,th,thead,tr{border-color:inherit;border-style:solid;border-width:0}label{display:inline-block}button{border-radius:0}button:focus{outline:dotted 1px;outline:-webkit-focus-ring-color auto 5px}button,input,optgroup,select,textarea{margin:0;font-family:inherit;font-size:inherit;line-height:inherit}button,select{text-transform:none}[role=button]{cursor:pointer}select{word-wrap:normal}[list]::-webkit-calendar-picker-indicator{display:none}[type=button],[type=reset],[type=submit],button{-webkit-appearance:button}[type=button]:not(:disabled),[type=reset]:not(:disabled),[type=submit]:not(:disabled),button:not(:disabled){cursor:pointer}::-moz-focus-inner{padding:0;border-style:none}textarea{resize:vertical}fieldset{min-width:0;padding:0;margin:0;border:0}legend{float:left;width:100%;padding:0;margin-bottom:.5rem;font-size:calc(1.275rem + .3vw);line-height:inherit}@media (min-width:1200px){legend{font-size:1.5rem}}legend+*{clear:left}::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-fields-wrapper,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-text,::-webkit-datetime-edit-year-field{padding:0}::-webkit-inner-spin-button{height:auto}[type=search]{outline-offset:-2px;-webkit-appearance:textfield}::-webkit-search-decoration{-webkit-appearance:none}::-webkit-color-swatch-wrapper{padding:0}::file-selector-button{font:inherit}::-webkit-file-upload-button{font:inherit;-webkit-appearance:button}output{display:inline-block}iframe{border:0}summary{display:list-item;cursor:pointer}progress{vertical-align:baseline}[hidden]{display:none!important}</style>
-<style type="text/css">/*! pygments syntax highlighting */pre{line-height:125%;}td.linenos pre{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}span.linenos{color:#000000; background-color:#f0f0f0; padding-left:5px; padding-right:5px;}td.linenos pre.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}span.linenos.special{color:#000000; background-color:#ffffc0; padding-left:5px; padding-right:5px;}.pdoc .hll{background-color:#ffffcc}.pdoc{background:#f8f8f8;}.pdoc .c{color:#408080; font-style:italic}.pdoc .err{border:1px solid #FF0000}.pdoc .k{color:#008000; font-weight:bold}.pdoc .o{color:#666666}.pdoc .ch{color:#408080; font-style:italic}.pdoc .cm{color:#408080; font-style:italic}.pdoc .cp{color:#BC7A00}.pdoc .cpf{color:#408080; font-style:italic}.pdoc .c1{color:#408080; font-style:italic}.pdoc .cs{color:#408080; font-style:italic}.pdoc .gd{color:#A00000}.pdoc .ge{font-style:italic}.pdoc .gr{color:#FF0000}.pdoc .gh{color:#000080; font-weight:bold}.pdoc .gi{color:#00A000}.pdoc .go{color:#888888}.pdoc .gp{color:#000080; font-weight:bold}.pdoc .gs{font-weight:bold}.pdoc .gu{color:#800080; font-weight:bold}.pdoc .gt{color:#0044DD}.pdoc .kc{color:#008000; font-weight:bold}.pdoc .kd{color:#008000; font-weight:bold}.pdoc .kn{color:#008000; font-weight:bold}.pdoc .kp{color:#008000}.pdoc .kr{color:#008000; font-weight:bold}.pdoc .kt{color:#B00040}.pdoc .m{color:#666666}.pdoc .s{color:#BA2121}.pdoc .na{color:#7D9029}.pdoc .nb{color:#008000}.pdoc .nc{color:#0000FF; font-weight:bold}.pdoc .no{color:#880000}.pdoc .nd{color:#AA22FF}.pdoc .ni{color:#999999; font-weight:bold}.pdoc .ne{color:#D2413A; font-weight:bold}.pdoc .nf{color:#0000FF}.pdoc .nl{color:#A0A000}.pdoc .nn{color:#0000FF; font-weight:bold}.pdoc .nt{color:#008000; font-weight:bold}.pdoc .nv{color:#19177C}.pdoc .ow{color:#AA22FF; font-weight:bold}.pdoc .w{color:#bbbbbb}.pdoc .mb{color:#666666}.pdoc .mf{color:#666666}.pdoc .mh{color:#666666}.pdoc .mi{color:#666666}.pdoc .mo{color:#666666}.pdoc .sa{color:#BA2121}.pdoc .sb{color:#BA2121}.pdoc .sc{color:#BA2121}.pdoc .dl{color:#BA2121}.pdoc .sd{color:#BA2121; font-style:italic}.pdoc .s2{color:#BA2121}.pdoc .se{color:#BB6622; font-weight:bold}.pdoc .sh{color:#BA2121}.pdoc .si{color:#BB6688; font-weight:bold}.pdoc .sx{color:#008000}.pdoc .sr{color:#BB6688}.pdoc .s1{color:#BA2121}.pdoc .ss{color:#19177C}.pdoc .bp{color:#008000}.pdoc .fm{color:#0000FF}.pdoc .vc{color:#19177C}.pdoc .vg{color:#19177C}.pdoc .vi{color:#19177C}.pdoc .vm{color:#19177C}.pdoc .il{color:#666666}</style>
-<style type="text/css">/*! pdoc */:root{--pdoc-background:#fff;}.pdoc{--text:#212529;--muted:#6c757d;--link:#3660a5;--link-hover:#1659c5;--code:#f7f7f7;--active:#fff598;--accent:#eee;--accent2:#c1c1c1;--nav-hover:rgba(255, 255, 255, 0.5);--name:#0066BB;--def:#008800;--annotation:#007020;}body{background-color:var(--pdoc-background);}html, body{width:100%;height:100%;}@media (max-width:769px){#navtoggle{cursor:pointer;position:absolute;width:50px;height:40px;top:1rem;right:1rem;border-color:var(--text);color:var(--text);display:flex;opacity:0.8;}#navtoggle:hover{opacity:1;}#togglestate + div{display:none;}#togglestate:checked + div{display:inherit;}main{padding:2rem 3vw;}.git-button{display:none !important;}}@media (min-width:770px){:root{--sidebar-width:clamp(12.5rem, 28vw, 22rem);}nav{position:fixed;overflow:auto;height:100vh;width:var(--sidebar-width);}main{padding:3rem 2rem 3rem calc(var(--sidebar-width) + 3rem);width:calc(54rem + var(--sidebar-width));max-width:100%;}#navtoggle{display:none;}}#togglestate{display:none;}nav.pdoc{--pad:1.75rem;--indent:1.5rem;background-color:var(--accent);border-right:1px solid var(--accent2);box-shadow:0 0 20px rgba(50, 50, 50, .2) inset;padding:0 0 0 var(--pad);overflow-wrap:anywhere;scrollbar-width:thin; scrollbar-color:var(--accent2) transparent }nav.pdoc::-webkit-scrollbar{width:.4rem; }nav.pdoc::-webkit-scrollbar-thumb{background-color:var(--accent2); }nav.pdoc > div{padding:var(--pad) 0;}nav.pdoc .module-list-button{display:inline-flex;align-items:center;color:var(--text);border-color:var(--muted);margin-bottom:1rem;}nav.pdoc .module-list-button:hover{border-color:var(--text);}nav.pdoc ul{list-style:none;padding-left:0;}nav.pdoc li{display:block;margin:0;padding:.2rem 0 .2rem var(--indent);transition:all 100ms;}nav.pdoc > div > ul > li{padding-left:0;}nav.pdoc li:hover{background-color:var(--nav-hover);}nav.pdoc a, nav.pdoc a:hover{color:var(--text);}nav.pdoc a{display:block;}nav.pdoc > h2:first-of-type{margin-top:1.5rem;}nav.pdoc .class:before{content:"class ";color:var(--muted);}nav.pdoc .function:after{content:"()";color:var(--muted);}html, main{scroll-behavior:smooth;}.pdoc{color:var(--text);box-sizing:border-box;line-height:1.5;background:none;}.pdoc .pdoc-button{display:inline-block;border:solid black 1px;border-radius:2px;font-size:.75rem;padding:calc(0.5em - 1px) 1em;transition:100ms all;}.pdoc .visually-hidden{position:absolute !important;width:1px !important;height:1px !important;padding:0 !important;margin:-1px !important;overflow:hidden !important;clip:rect(0, 0, 0, 0) !important;white-space:nowrap !important;border:0 !important;}.pdoc h1, .pdoc h2, .pdoc h3, .pdoc h4{font-weight:300;margin:.3em 0;padding:.2em 0;}.pdoc a{text-decoration:none;color:var(--link);}.pdoc a:hover{color:var(--link-hover);}.pdoc blockquote{margin-left:2rem;}.pdoc pre{background-color:var(--code);border-top:1px solid var(--accent2);border-bottom:1px solid var(--accent2);margin-bottom:1em;padding:.5rem 0 .5rem .5rem;overflow-x:auto;}.pdoc code{color:var(--text);padding:.2em .4em;margin:0;font-size:85%;background-color:var(--code);border-radius:6px;}.pdoc a > code{color:inherit;}.pdoc pre > code{display:inline-block;font-size:inherit;background:none;border:none;padding:0;}.pdoc .modulename{margin-top:0;font-weight:bold;}.pdoc .modulename a{color:var(--link);transition:100ms all;}.pdoc .git-button{float:right;border:solid var(--link) 1px;}.pdoc .git-button:hover{background-color:var(--link);color:var(--pdoc-background);}.pdoc details{--shift:-40px;text-align:right;margin-top:var(--shift);margin-bottom:calc(0px - var(--shift));clear:both;filter:opacity(1);}.pdoc details:not([open]){height:0;overflow:visible;}.pdoc details > summary{font-size:.75rem;cursor:pointer;color:var(--muted);border-width:0;padding:0 .7em;display:inline-block;display:inline list-item;user-select:none;}.pdoc details > summary:focus{outline:0;}.pdoc details > div{margin-top:calc(0px - var(--shift) / 2);text-align:left;}.pdoc .docstring{margin-bottom:1.5rem;}.pdoc > section:first-of-type > .docstring{margin-bottom:3rem;}.pdoc .docstring pre{margin-left:1em;margin-right:1em;}.pdoc h1:target,.pdoc h2:target,.pdoc h3:target,.pdoc h4:target,.pdoc h5:target,.pdoc h6:target{background-color:var(--active);box-shadow:-1rem 0 0 0 var(--active);}.pdoc div:target > .attr,.pdoc section:target > .attr,.pdoc dd:target > a{background-color:var(--active);}.pdoc .attr:hover{filter:contrast(0.95);}.pdoc .headerlink{position:absolute;width:0;margin-left:-1.5rem;line-height:1.4rem;font-size:1.5rem;font-weight:normal;transition:all 100ms ease-in-out;opacity:0;}.pdoc .attr > .headerlink{margin-left:-2.5rem;}.pdoc *:hover > .headerlink,.pdoc *:target > .attr > .headerlink{opacity:1;}.pdoc .attr{color:var(--text);margin:1rem 0 .5rem;padding:.4rem 5rem .4rem 1rem;background-color:var(--accent);}.pdoc .classattr{margin-left:2rem;}.pdoc .name{color:var(--name);font-weight:bold;}.pdoc .def{color:var(--def);font-weight:bold;}.pdoc .signature{white-space:pre-wrap;}.pdoc .annotation{color:var(--annotation);}.pdoc .inherited{margin-left:2rem;}.pdoc .inherited dt{font-weight:700;}.pdoc .inherited dt, .pdoc .inherited dd{display:inline;margin-left:0;margin-bottom:.5rem;}.pdoc .inherited dd:not(:last-child):after{content:", ";}.pdoc .inherited .class:before{content:"class ";}.pdoc .inherited .function a:after{content:"()";}.pdoc .attribution{margin-top:2rem;display:block;opacity:0.5;transition:all 200ms;filter:grayscale(100%);}.pdoc .attribution:hover{opacity:1;filter:grayscale(0%);}.pdoc .attribution img{margin-left:5px;height:35px;vertical-align:middle;width:70px;transition:all 200ms;}</style>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.10.0" />
+<title>stream.util.optional API documentation</title>
+<meta name="description" content="" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
 </head>
-<body>        <nav class="pdoc">
-            <label id="navtoggle" for="togglestate" class="pdoc-button"><svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'><path stroke-linecap='round' stroke="currentColor" stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/></svg></label>
-            <input id="togglestate" type="checkbox">
-            <div>
-                        <a class="pdoc-button module-list-button" href="../util.html">
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-box-arrow-in-left" viewBox="0 0 16 16">
-  <path fill-rule="evenodd" d="M10 3.5a.5.5 0 0 0-.5-.5h-8a.5.5 0 0 0-.5.5v9a.5.5 0 0 0 .5.5h8a.5.5 0 0 0 .5-.5v-2a.5.5 0 0 1 1 0v2A1.5 1.5 0 0 1 9.5 14h-8A1.5 1.5 0 0 1 0 12.5v-9A1.5 1.5 0 0 1 1.5 2h8A1.5 1.5 0 0 1 11 3.5v2a.5.5 0 0 1-1 0v-2z"/>
-  <path fill-rule="evenodd" d="M4.146 8.354a.5.5 0 0 1 0-.708l3-3a.5.5 0 1 1 .708.708L5.707 7.5H14.5a.5.5 0 0 1 0 1H5.707l2.147 2.146a.5.5 0 0 1-.708.708l-3-3z"/>
-</svg>                            &nbsp;stream.util</a>
-
-
-
-
-                    <h2>API Documentation</h2>
-                        <ul class="memberlist">
-            <li>
-                    <a class="class" href="#Optional">Optional</a>
-                            <ul class="memberlist">
-                        <li>
-                                <a class="function" href="#Optional.__init__">Optional</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.empty">empty</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.of">of</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.ofNullable">ofNullable</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.get">get</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.isPresent">isPresent</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.isEmpty">isEmpty</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.ifPresent">ifPresent</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.ifPresentOrElse">ifPresentOrElse</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.filter">filter</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#Optional.map">map</a>
-                        </li>
-                </ul>
-
-            </li>
-    </ul>
-
-
-                    <a class="attribution" title="pdoc: Python API documentation generator" href="https://pdoc.dev">
-                        built with <span class="visually-hidden">pdoc</span><img
-                            alt="pdoc logo"
-                            src="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%20role%3D%22img%22%20aria-label%3D%22pdoc%20logo%22%20width%3D%22300%22%20height%3D%22150%22%20viewBox%3D%22-1%200%2060%2030%22%3E%3Ctitle%3Epdoc%3C/title%3E%3Cpath%20d%3D%22M29.621%2021.293c-.011-.273-.214-.475-.511-.481a.5.5%200%200%200-.489.503l-.044%201.393c-.097.551-.695%201.215-1.566%201.704-.577.428-1.306.486-2.193.182-1.426-.617-2.467-1.654-3.304-2.487l-.173-.172a3.43%203.43%200%200%200-.365-.306.49.49%200%200%200-.286-.196c-1.718-1.06-4.931-1.47-7.353.191l-.219.15c-1.707%201.187-3.413%202.131-4.328%201.03-.02-.027-.49-.685-.141-1.763.233-.721.546-2.408.772-4.076.042-.09.067-.187.046-.288.166-1.347.277-2.625.241-3.351%201.378-1.008%202.271-2.586%202.271-4.362%200-.976-.272-1.935-.788-2.774-.057-.094-.122-.18-.184-.268.033-.167.052-.339.052-.516%200-1.477-1.202-2.679-2.679-2.679-.791%200-1.496.352-1.987.9a6.3%206.3%200%200%200-1.001.029c-.492-.564-1.207-.929-2.012-.929-1.477%200-2.679%201.202-2.679%202.679A2.65%202.65%200%200%200%20.97%206.554c-.383.747-.595%201.572-.595%202.41%200%202.311%201.507%204.29%203.635%205.107-.037.699-.147%202.27-.423%203.294l-.137.461c-.622%202.042-2.515%208.257%201.727%2010.643%201.614.908%203.06%201.248%204.317%201.248%202.665%200%204.492-1.524%205.322-2.401%201.476-1.559%202.886-1.854%206.491.82%201.877%201.393%203.514%201.753%204.861%201.068%202.223-1.713%202.811-3.867%203.399-6.374.077-.846.056-1.469.054-1.537zm-4.835%204.313c-.054.305-.156.586-.242.629-.034-.007-.131-.022-.307-.157-.145-.111-.314-.478-.456-.908.221.121.432.25.675.355.115.039.219.051.33.081zm-2.251-1.238c-.05.33-.158.648-.252.694-.022.001-.125-.018-.307-.157-.217-.166-.488-.906-.639-1.573.358.344.754.693%201.198%201.036zm-3.887-2.337c-.006-.116-.018-.231-.041-.342.635.145%201.189.368%201.599.625.097.231.166.481.174.642-.03.049-.055.101-.067.158-.046.013-.128.026-.298.004-.278-.037-.901-.57-1.367-1.087zm-1.127-.497c.116.306.176.625.12.71-.019.014-.117.045-.345.016-.206-.027-.604-.332-.986-.695.41-.051.816-.056%201.211-.031zm-4.535%201.535c.209.22.379.47.358.598-.006.041-.088.138-.351.234-.144.055-.539-.063-.979-.259a11.66%2011.66%200%200%200%20.972-.573zm.983-.664c.359-.237.738-.418%201.126-.554.25.237.479.548.457.694-.006.042-.087.138-.351.235-.174.064-.694-.105-1.232-.375zm-3.381%201.794c-.022.145-.061.29-.149.401-.133.166-.358.248-.69.251h-.002c-.133%200-.306-.26-.45-.621.417.091.854.07%201.291-.031zm-2.066-8.077a4.78%204.78%200%200%201-.775-.584c.172-.115.505-.254.88-.378l-.105.962zm-.331%202.302a10.32%2010.32%200%200%201-.828-.502c.202-.143.576-.328.984-.49l-.156.992zm-.45%202.157l-.701-.403c.214-.115.536-.249.891-.376a11.57%2011.57%200%200%201-.19.779zm-.181%201.716c.064.398.194.702.298.893-.194-.051-.435-.162-.736-.398.061-.119.224-.3.438-.495zM8.87%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zm-.735-.389a1.15%201.15%200%200%200-.314.783%201.16%201.16%200%200%200%201.162%201.162c.457%200%20.842-.27%201.032-.653.026.117.042.238.042.362a1.68%201.68%200%200%201-1.679%201.679%201.68%201.68%200%200%201-1.679-1.679c0-.843.626-1.535%201.436-1.654zM5.059%205.406A1.68%201.68%200%200%201%203.38%207.085a1.68%201.68%200%200%201-1.679-1.679c0-.037.009-.072.011-.109.21.3.541.508.935.508a1.16%201.16%200%200%200%201.162-1.162%201.14%201.14%200%200%200-.474-.912c.015%200%20.03-.005.045-.005.926.001%201.679.754%201.679%201.68zM3.198%204.141c0%20.152-.123.276-.276.276s-.275-.124-.275-.276.123-.276.276-.276.275.124.275.276zM1.375%208.964c0-.52.103-1.035.288-1.52.466.394%201.06.64%201.717.64%201.144%200%202.116-.725%202.499-1.738.383%201.012%201.355%201.738%202.499%201.738.867%200%201.631-.421%202.121-1.062.307.605.478%201.267.478%201.942%200%202.486-2.153%204.51-4.801%204.51s-4.801-2.023-4.801-4.51zm24.342%2019.349c-.985.498-2.267.168-3.813-.979-3.073-2.281-5.453-3.199-7.813-.705-1.315%201.391-4.163%203.365-8.423.97-3.174-1.786-2.239-6.266-1.261-9.479l.146-.492c.276-1.02.395-2.457.444-3.268a6.11%206.11%200%200%200%201.18.115%206.01%206.01%200%200%200%202.536-.562l-.006.175c-.802.215-1.848.612-2.021%201.25-.079.295.021.601.274.837.219.203.415.364.598.501-.667.304-1.243.698-1.311%201.179-.02.144-.022.507.393.787.213.144.395.26.564.365-1.285.521-1.361.96-1.381%201.126-.018.142-.011.496.427.746l.854.489c-.473.389-.971.914-.999%201.429-.018.278.095.532.316.713.675.556%201.231.721%201.653.721.059%200%20.104-.014.158-.02.207.707.641%201.64%201.513%201.64h.013c.8-.008%201.236-.345%201.462-.626.173-.216.268-.457.325-.692.424.195.93.374%201.372.374.151%200%20.294-.021.423-.068.732-.27.944-.704.993-1.021.009-.061.003-.119.002-.179.266.086.538.147.789.147.15%200%20.294-.021.423-.069.542-.2.797-.489.914-.754.237.147.478.258.704.288.106.014.205.021.296.021.356%200%20.595-.101.767-.229.438.435%201.094.992%201.656%201.067.106.014.205.021.296.021a1.56%201.56%200%200%200%20.323-.035c.17.575.453%201.289.866%201.605.358.273.665.362.914.362a.99.99%200%200%200%20.421-.093%201.03%201.03%200%200%200%20.245-.164c.168.428.39.846.68%201.068.358.273.665.362.913.362a.99.99%200%200%200%20.421-.093c.317-.148.512-.448.639-.762.251.157.495.257.726.257.127%200%20.25-.024.37-.071.427-.17.706-.617.841-1.314.022-.015.047-.022.068-.038.067-.051.133-.104.196-.159-.443%201.486-1.107%202.761-2.086%203.257zM8.66%209.925a.5.5%200%201%200-1%200c0%20.653-.818%201.205-1.787%201.205s-1.787-.552-1.787-1.205a.5.5%200%201%200-1%200c0%201.216%201.25%202.205%202.787%202.205s2.787-.989%202.787-2.205zm4.4%2015.965l-.208.097c-2.661%201.258-4.708%201.436-6.086.527-1.542-1.017-1.88-3.19-1.844-4.198a.4.4%200%200%200-.385-.414c-.242-.029-.406.164-.414.385-.046%201.249.367%203.686%202.202%204.896.708.467%201.547.7%202.51.7%201.248%200%202.706-.392%204.362-1.174l.185-.086a.4.4%200%200%200%20.205-.527c-.089-.204-.326-.291-.527-.206zM9.547%202.292c.093.077.205.114.317.114a.5.5%200%200%200%20.318-.886L8.817.397a.5.5%200%200%200-.703.068.5.5%200%200%200%20.069.703l1.364%201.124zm-7.661-.065c.086%200%20.173-.022.253-.068l1.523-.893a.5.5%200%200%200-.506-.863l-1.523.892a.5.5%200%200%200-.179.685c.094.158.261.247.432.247z%22%20transform%3D%22matrix%28-1%200%200%201%2058%200%29%22%20fill%3D%22%233bb300%22/%3E%3Cpath%20d%3D%22M.3%2021.86V10.18q0-.46.02-.68.04-.22.18-.5.28-.54%201.34-.54%201.06%200%201.42.28.38.26.44.78.76-1.04%202.38-1.04%201.64%200%203.1%201.54%201.46%201.54%201.46%203.58%200%202.04-1.46%203.58-1.44%201.54-3.08%201.54-1.64%200-2.38-.92v4.04q0%20.46-.04.68-.02.22-.18.5-.14.3-.5.42-.36.12-.98.12-.62%200-1-.12-.36-.12-.52-.4-.14-.28-.18-.5-.02-.22-.02-.68zm3.96-9.42q-.46.54-.46%201.18%200%20.64.46%201.18.48.52%201.2.52.74%200%201.24-.52.52-.52.52-1.18%200-.66-.48-1.18-.48-.54-1.26-.54-.76%200-1.22.54zm14.741-8.36q.16-.3.54-.42.38-.12%201-.12.64%200%201.02.12.38.12.52.42.16.3.18.54.04.22.04.68v11.94q0%20.46-.04.7-.02.22-.18.5-.3.54-1.7.54-1.38%200-1.54-.98-.84.96-2.34.96-1.8%200-3.28-1.56-1.48-1.58-1.48-3.66%200-2.1%201.48-3.68%201.5-1.58%203.28-1.58%201.48%200%202.3%201v-4.2q0-.46.02-.68.04-.24.18-.52zm-3.24%2010.86q.52.54%201.26.54.74%200%201.22-.54.5-.54.5-1.18%200-.66-.48-1.22-.46-.56-1.26-.56-.8%200-1.28.56-.48.54-.48%201.2%200%20.66.52%201.2zm7.833-1.2q0-2.4%201.68-3.96%201.68-1.56%203.84-1.56%202.16%200%203.82%201.56%201.66%201.54%201.66%203.94%200%201.66-.86%202.96-.86%201.28-2.1%201.9-1.22.6-2.54.6-1.32%200-2.56-.64-1.24-.66-2.1-1.92-.84-1.28-.84-2.88zm4.18%201.44q.64.48%201.3.48.66%200%201.32-.5.66-.5.66-1.48%200-.98-.62-1.46-.62-.48-1.34-.48-.72%200-1.34.5-.62.5-.62%201.48%200%20.96.64%201.46zm11.412-1.44q0%20.84.56%201.32.56.46%201.18.46.64%200%201.18-.36.56-.38.9-.38.6%200%201.46%201.06.46.58.46%201.04%200%20.76-1.1%201.42-1.14.8-2.8.8-1.86%200-3.58-1.34-.82-.64-1.34-1.7-.52-1.08-.52-2.36%200-1.3.52-2.34.52-1.06%201.34-1.7%201.66-1.32%203.54-1.32.76%200%201.48.22.72.2%201.06.4l.32.2q.36.24.56.38.52.4.52.92%200%20.5-.42%201.14-.72%201.1-1.38%201.1-.38%200-1.08-.44-.36-.34-1.04-.34-.66%200-1.24.48-.58.48-.58%201.34z%22%20fill%3D%22green%22/%3E%3C/svg%3E"/>
-                    </a>
-            </div>
-        </nav>
-    <main class="pdoc">
-            <section>
-                    <h1 class="modulename">
-<a href="./../../stream.html">stream</a>.<a href="./../util.html">util</a>.optional    </h1>
-
-                
-                        <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Optional</span><span class="p">:</span>
-
-    <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">    A container object which may or may not contain a non-null value. If a value is present, isPresent() returns true. If no value is present, the object is considered empty and isPresent() returns false.</span>
-
-<span class="sd">    Additional methods that depend on the presence or absence of a contained value are provided, such as orElse() (returns a default value if no value is present) and ifPresent() (performs an action if a value is present). </span>
-<span class="sd">    &#39;&#39;&#39;</span>
-
-    <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">    STATIC METHODS</span>
-<span class="sd">    &#39;&#39;&#39;</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">empty</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an empty Optional instance. No value is present for this Optional.</span>
-
-<span class="sd">        :return: an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the given non-null value.</span>
-
-<span class="sd">        :param T elem: the value to describe, which must be non-null</span>
-<span class="sd">        :return: an Optional with the value present</span>
-<span class="sd">        :raise: Exception if the value is null</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="n">elem</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
-            <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s2">&quot;Optional Empty&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">ofNullable</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.</span>
-
-<span class="sd">        :param T elem: the possibly-null value to describe</span>
-<span class="sd">        :return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-
-    <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">    NON STATIC METHODS</span>
-<span class="sd">    &#39;&#39;&#39;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">elem</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span> <span class="o">=</span> <span class="n">elem</span>
-
-    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns the value, otherwise raise an Exception.</span>
-
-<span class="sd">        :return: the non-null value described by this Optional</span>
-<span class="sd">        :raise: Exception if no value is present</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isEmpty</span><span class="p">():</span>
-            <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s2">&quot;Optional Empty&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span>
-
-    <span class="k">def</span> <span class="nf">isPresent</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns true, otherwise false.</span>
-
-<span class="sd">        :return: true if a value is present, otherwise false</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">isEmpty</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">isEmpty</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is not present, returns true, otherwise false.</span>
-
-<span class="sd">        :return: true if a value is not present, otherwise false</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span> <span class="ow">is</span> <span class="kc">None</span>
-
-    <span class="k">def</span> <span class="nf">ifPresent</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">action</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, performs the given action with the value, otherwise does nothing.</span>
-
-<span class="sd">        :param Function action: the action to be performed, if a value is present</span>
-<span class="sd">        :raise Exception if value is present and the given action is null</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="n">action</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">())</span>
-
-    <span class="k">def</span> <span class="nf">ifPresentOrElse</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">action</span><span class="p">,</span> <span class="n">emptyAction</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, performs the given action with the value, otherwise performs the given empty-based action.</span>
-
-<span class="sd">        :param Function action: the action to be performed, if a value is present</span>
-<span class="sd">        :param Function emptyAction: the empty-based action to be performed, if no value is present</span>
-<span class="sd">        :raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="n">action</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">())</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="n">emptyAction</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.</span>
-
-<span class="sd">        :param Predicate predicate: the predicate to apply to a value, if present</span>
-<span class="sd">        :return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">()</span> <span class="ow">and</span> <span class="n">predicate</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">()):</span>
-            <span class="k">return</span> <span class="bp">self</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional. </span>
-<span class="sd">        If the mapping function returns a null result then this method returns an empty Optional.</span>
-
-<span class="sd">        :param Mapper mapper: the mapping function to apply to a value, if present</span>
-<span class="sd">        :return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="n">mapper</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">()))</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            </section>
-                <section id="Optional">
-                                <div class="attr class">
-        <a class="headerlink" href="#Optional">#&nbsp;&nbsp</a>
-
-        
-        <span class="def">class</span>
-        <span class="name">Optional</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span><span class="k">class</span> <span class="nc">Optional</span><span class="p">:</span>
-
-    <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">    A container object which may or may not contain a non-null value. If a value is present, isPresent() returns true. If no value is present, the object is considered empty and isPresent() returns false.</span>
-
-<span class="sd">    Additional methods that depend on the presence or absence of a contained value are provided, such as orElse() (returns a default value if no value is present) and ifPresent() (performs an action if a value is present). </span>
-<span class="sd">    &#39;&#39;&#39;</span>
-
-    <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">    STATIC METHODS</span>
-<span class="sd">    &#39;&#39;&#39;</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">empty</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an empty Optional instance. No value is present for this Optional.</span>
-
-<span class="sd">        :return: an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the given non-null value.</span>
-
-<span class="sd">        :param T elem: the value to describe, which must be non-null</span>
-<span class="sd">        :return: an Optional with the value present</span>
-<span class="sd">        :raise: Exception if the value is null</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="n">elem</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
-            <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s2">&quot;Optional Empty&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-
-    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">ofNullable</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.</span>
-
-<span class="sd">        :param T elem: the possibly-null value to describe</span>
-<span class="sd">        :return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-
-    <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">    NON STATIC METHODS</span>
-<span class="sd">    &#39;&#39;&#39;</span>
-
-    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">elem</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span> <span class="o">=</span> <span class="n">elem</span>
-
-    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns the value, otherwise raise an Exception.</span>
-
-<span class="sd">        :return: the non-null value described by this Optional</span>
-<span class="sd">        :raise: Exception if no value is present</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isEmpty</span><span class="p">():</span>
-            <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s2">&quot;Optional Empty&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span>
-
-    <span class="k">def</span> <span class="nf">isPresent</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns true, otherwise false.</span>
-
-<span class="sd">        :return: true if a value is present, otherwise false</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">isEmpty</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">isEmpty</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is not present, returns true, otherwise false.</span>
-
-<span class="sd">        :return: true if a value is not present, otherwise false</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span> <span class="ow">is</span> <span class="kc">None</span>
-
-    <span class="k">def</span> <span class="nf">ifPresent</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">action</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, performs the given action with the value, otherwise does nothing.</span>
-
-<span class="sd">        :param Function action: the action to be performed, if a value is present</span>
-<span class="sd">        :raise Exception if value is present and the given action is null</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="n">action</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">())</span>
-
-    <span class="k">def</span> <span class="nf">ifPresentOrElse</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">action</span><span class="p">,</span> <span class="n">emptyAction</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, performs the given action with the value, otherwise performs the given empty-based action.</span>
-
-<span class="sd">        :param Function action: the action to be performed, if a value is present</span>
-<span class="sd">        :param Function emptyAction: the empty-based action to be performed, if no value is present</span>
-<span class="sd">        :raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="n">action</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">())</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="n">emptyAction</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.</span>
-
-<span class="sd">        :param Predicate predicate: the predicate to apply to a value, if present</span>
-<span class="sd">        :return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">()</span> <span class="ow">and</span> <span class="n">predicate</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">()):</span>
-            <span class="k">return</span> <span class="bp">self</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-
-    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional. </span>
-<span class="sd">        If the mapping function returns a null result then this method returns an empty Optional.</span>
-
-<span class="sd">        :param Mapper mapper: the mapping function to apply to a value, if present</span>
-<span class="sd">        :return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="n">mapper</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">()))</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>A container object which may or may not contain a non-null value. If a value is present, isPresent() returns true. If no value is present, the object is considered empty and isPresent() returns false.</p>
-
-<p>Additional methods that depend on the presence or absence of a contained value are provided, such as orElse() (returns a default value if no value is present) and ifPresent() (performs an action if a value is present).</p>
-</div>
-
-
-                            <div id="Optional.__init__" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.__init__">#&nbsp;&nbsp</a>
-
-        
-            <span class="name">Optional</span><span class="signature">(elem)</span>    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="fm">__init__</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">elem</span><span class="p">):</span>
-        <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span> <span class="o">=</span> <span class="n">elem</span>
-</pre></div>
-
-        </details>
-
-    
-
-                            </div>
-                            <div id="Optional.empty" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.empty">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">empty</span><span class="signature">()</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">empty</span><span class="p">():</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an empty Optional instance. No value is present for this Optional.</span>
-
-<span class="sd">        :return: an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="kc">None</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an empty Optional instance. No value is present for this Optional.</p>
-
-<p>:return: an empty Optional</p>
-</div>
-
-
-                            </div>
-                            <div id="Optional.of" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.of">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">of</span><span class="signature">(elem)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">of</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the given non-null value.</span>
-
-<span class="sd">        :param T elem: the value to describe, which must be non-null</span>
-<span class="sd">        :return: an Optional with the value present</span>
-<span class="sd">        :raise: Exception if the value is null</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="n">elem</span> <span class="ow">is</span> <span class="kc">None</span><span class="p">:</span>
-            <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s2">&quot;Optional Empty&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an Optional describing the given non-null value.</p>
-
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>stream.util.optional</code></h1>
+</header>
+<section id="section-intro">
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Optional:
+
+    &#39;&#39;&#39;
+    A container object which may or may not contain a non-null value. If a value is present, isPresent() returns true. If no value is present, the object is considered empty and isPresent() returns false.
+
+    Additional methods that depend on the presence or absence of a contained value are provided, such as orElse() (returns a default value if no value is present) and ifPresent() (performs an action if a value is present). 
+    &#39;&#39;&#39;
+
+    &#39;&#39;&#39;
+    STATIC METHODS
+    &#39;&#39;&#39;
+
+    @staticmethod
+    def empty():
+        &#39;&#39;&#39;
+        Returns an empty Optional instance. No value is present for this Optional.
+
+        :return: an empty Optional
+        &#39;&#39;&#39;
+        return Optional(None)
+
+    @staticmethod
+    def of(elem):
+        &#39;&#39;&#39;
+        Returns an Optional describing the given non-null value.
+
+        :param T elem: the value to describe, which must be non-null
+        :return: an Optional with the value present
+        :raise: Exception if the value is null
+        &#39;&#39;&#39;
+        if elem is None:
+            raise Exception(&#34;Optional Empty&#34;)
+        return Optional(elem)
+
+    @staticmethod
+    def ofNullable(elem):
+        &#39;&#39;&#39;
+        Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.
+
+        :param T elem: the possibly-null value to describe
+        :return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional
+        &#39;&#39;&#39;
+        return Optional(elem)
+
+    &#39;&#39;&#39;
+    NON STATIC METHODS
+    &#39;&#39;&#39;
+
+    def __init__(self, elem):
+        self.__elem = elem
+
+    def get(self):
+        &#39;&#39;&#39;
+        If a value is present, returns the value, otherwise raise an Exception.
+
+        :return: the non-null value described by this Optional
+        :raise: Exception if no value is present
+        &#39;&#39;&#39;
+        if self.isEmpty():
+            raise Exception(&#34;Optional Empty&#34;)
+        return self.__elem
+
+    def isPresent(self):
+        &#39;&#39;&#39;
+        If a value is present, returns true, otherwise false.
+
+        :return: true if a value is present, otherwise false
+        &#39;&#39;&#39;
+        return not self.isEmpty()
+
+    def isEmpty(self):
+        &#39;&#39;&#39;
+        If a value is not present, returns true, otherwise false.
+
+        :return: true if a value is not present, otherwise false
+        &#39;&#39;&#39;
+        return self.__elem is None
+
+    def ifPresent(self, action):
+        &#39;&#39;&#39;
+        If a value is present, performs the given action with the value, otherwise does nothing.
+
+        :param Function action: the action to be performed, if a value is present
+        :raise Exception if value is present and the given action is null
+        &#39;&#39;&#39;
+        if self.isPresent():
+            action(self.get())
+
+    def ifPresentOrElse(self, action, emptyAction):
+        &#39;&#39;&#39;
+        If a value is present, performs the given action with the value, otherwise performs the given empty-based action.
+
+        :param Function action: the action to be performed, if a value is present
+        :param Function emptyAction: the empty-based action to be performed, if no value is present
+        :raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.
+        &#39;&#39;&#39;
+        if self.isPresent():
+            action(self.get())
+        else:
+            emptyAction()
+
+    def orElse(self, value):
+        &#39;&#39;&#39;
+        Returns the value if present, or a provided argument otherwise. It&#39;s a safe alternative to get() method.
+
+        :return: the non-null value described by this Optional or the value passed as an argument
+        &#39;&#39;&#39;
+        return self.__elem if self.isPresent() else value
+
+    def orElseGet(self, supplier):
+        &#39;&#39;&#39;
+        Returns either a stored value, or calls a supplier otherwise. It&#39;s a safe alternative to get() method.
+
+        :return: the non-null value described by this Optional or the result of supplier argument
+        &#39;&#39;&#39;
+        return self.__elem if self.isPresent() else supplier()
+
+    def filter(self, predicate):
+        &#39;&#39;&#39;
+        If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.
+
+        :param Predicate predicate: the predicate to apply to a value, if present
+        :return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional
+        &#39;&#39;&#39;
+        if self.isPresent() and predicate(self.get()):
+            return self
+        else:
+            return Optional.empty()
+
+    def map(self, mapper):
+        &#39;&#39;&#39;
+        If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional. 
+        If the mapping function returns a null result then this method returns an empty Optional.
+
+        :param Mapper mapper: the mapping function to apply to a value, if present
+        :return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional
+        &#39;&#39;&#39;
+        if self.isPresent():
+            return Optional.ofNullable(mapper(self.get()))
+        else:
+            return Optional.empty()</code></pre>
+</details>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="stream.util.optional.Optional"><code class="flex name class">
+<span>class <span class="ident">Optional</span></span>
+<span>(</span><span>elem)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A container object which may or may not contain a non-null value. If a value is present, isPresent() returns true. If no value is present, the object is considered empty and isPresent() returns false.</p>
+<p>Additional methods that depend on the presence or absence of a contained value are provided, such as orElse() (returns a default value if no value is present) and ifPresent() (performs an action if a value is present).</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">class Optional:
+
+    &#39;&#39;&#39;
+    A container object which may or may not contain a non-null value. If a value is present, isPresent() returns true. If no value is present, the object is considered empty and isPresent() returns false.
+
+    Additional methods that depend on the presence or absence of a contained value are provided, such as orElse() (returns a default value if no value is present) and ifPresent() (performs an action if a value is present). 
+    &#39;&#39;&#39;
+
+    &#39;&#39;&#39;
+    STATIC METHODS
+    &#39;&#39;&#39;
+
+    @staticmethod
+    def empty():
+        &#39;&#39;&#39;
+        Returns an empty Optional instance. No value is present for this Optional.
+
+        :return: an empty Optional
+        &#39;&#39;&#39;
+        return Optional(None)
+
+    @staticmethod
+    def of(elem):
+        &#39;&#39;&#39;
+        Returns an Optional describing the given non-null value.
+
+        :param T elem: the value to describe, which must be non-null
+        :return: an Optional with the value present
+        :raise: Exception if the value is null
+        &#39;&#39;&#39;
+        if elem is None:
+            raise Exception(&#34;Optional Empty&#34;)
+        return Optional(elem)
+
+    @staticmethod
+    def ofNullable(elem):
+        &#39;&#39;&#39;
+        Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.
+
+        :param T elem: the possibly-null value to describe
+        :return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional
+        &#39;&#39;&#39;
+        return Optional(elem)
+
+    &#39;&#39;&#39;
+    NON STATIC METHODS
+    &#39;&#39;&#39;
+
+    def __init__(self, elem):
+        self.__elem = elem
+
+    def get(self):
+        &#39;&#39;&#39;
+        If a value is present, returns the value, otherwise raise an Exception.
+
+        :return: the non-null value described by this Optional
+        :raise: Exception if no value is present
+        &#39;&#39;&#39;
+        if self.isEmpty():
+            raise Exception(&#34;Optional Empty&#34;)
+        return self.__elem
+
+    def isPresent(self):
+        &#39;&#39;&#39;
+        If a value is present, returns true, otherwise false.
+
+        :return: true if a value is present, otherwise false
+        &#39;&#39;&#39;
+        return not self.isEmpty()
+
+    def isEmpty(self):
+        &#39;&#39;&#39;
+        If a value is not present, returns true, otherwise false.
+
+        :return: true if a value is not present, otherwise false
+        &#39;&#39;&#39;
+        return self.__elem is None
+
+    def ifPresent(self, action):
+        &#39;&#39;&#39;
+        If a value is present, performs the given action with the value, otherwise does nothing.
+
+        :param Function action: the action to be performed, if a value is present
+        :raise Exception if value is present and the given action is null
+        &#39;&#39;&#39;
+        if self.isPresent():
+            action(self.get())
+
+    def ifPresentOrElse(self, action, emptyAction):
+        &#39;&#39;&#39;
+        If a value is present, performs the given action with the value, otherwise performs the given empty-based action.
+
+        :param Function action: the action to be performed, if a value is present
+        :param Function emptyAction: the empty-based action to be performed, if no value is present
+        :raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.
+        &#39;&#39;&#39;
+        if self.isPresent():
+            action(self.get())
+        else:
+            emptyAction()
+
+    def orElse(self, value):
+        &#39;&#39;&#39;
+        Returns the value if present, or a provided argument otherwise. It&#39;s a safe alternative to get() method.
+
+        :return: the non-null value described by this Optional or the value passed as an argument
+        &#39;&#39;&#39;
+        return self.__elem if self.isPresent() else value
+
+    def orElseGet(self, supplier):
+        &#39;&#39;&#39;
+        Returns either a stored value, or calls a supplier otherwise. It&#39;s a safe alternative to get() method.
+
+        :return: the non-null value described by this Optional or the result of supplier argument
+        &#39;&#39;&#39;
+        return self.__elem if self.isPresent() else supplier()
+
+    def filter(self, predicate):
+        &#39;&#39;&#39;
+        If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.
+
+        :param Predicate predicate: the predicate to apply to a value, if present
+        :return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional
+        &#39;&#39;&#39;
+        if self.isPresent() and predicate(self.get()):
+            return self
+        else:
+            return Optional.empty()
+
+    def map(self, mapper):
+        &#39;&#39;&#39;
+        If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional. 
+        If the mapping function returns a null result then this method returns an empty Optional.
+
+        :param Mapper mapper: the mapping function to apply to a value, if present
+        :return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional
+        &#39;&#39;&#39;
+        if self.isPresent():
+            return Optional.ofNullable(mapper(self.get()))
+        else:
+            return Optional.empty()</code></pre>
+</details>
+<h3>Static methods</h3>
+<dl>
+<dt id="stream.util.optional.Optional.empty"><code class="name flex">
+<span>def <span class="ident">empty</span></span>(<span>)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an empty Optional instance. No value is present for this Optional.</p>
+<p>:return: an empty Optional</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def empty():
+    &#39;&#39;&#39;
+    Returns an empty Optional instance. No value is present for this Optional.
+
+    :return: an empty Optional
+    &#39;&#39;&#39;
+    return Optional(None)</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.of"><code class="name flex">
+<span>def <span class="ident">of</span></span>(<span>elem)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an Optional describing the given non-null value.</p>
 <p>:param T elem: the value to describe, which must be non-null
 :return: an Optional with the value present
-:raise: Exception if the value is null</p>
-</div>
+:raise: Exception if the value is null</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def of(elem):
+    &#39;&#39;&#39;
+    Returns an Optional describing the given non-null value.
 
-
-                            </div>
-                            <div id="Optional.ofNullable" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.ofNullable">#&nbsp;&nbsp</a>
-
-                <div class="decorator">@staticmethod</div>
-
-            <span class="def">def</span>
-            <span class="name">ofNullable</span><span class="signature">(elem)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="nd">@staticmethod</span>
-    <span class="k">def</span> <span class="nf">ofNullable</span><span class="p">(</span><span class="n">elem</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.</span>
-
-<span class="sd">        :param T elem: the possibly-null value to describe</span>
-<span class="sd">        :return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="n">Optional</span><span class="p">(</span><span class="n">elem</span><span class="p">)</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.</p>
-
+    :param T elem: the value to describe, which must be non-null
+    :return: an Optional with the value present
+    :raise: Exception if the value is null
+    &#39;&#39;&#39;
+    if elem is None:
+        raise Exception(&#34;Optional Empty&#34;)
+    return Optional(elem)</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.ofNullable"><code class="name flex">
+<span>def <span class="ident">ofNullable</span></span>(<span>elem)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.</p>
 <p>:param T elem: the possibly-null value to describe
-:return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional</p>
-</div>
+:return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">@staticmethod
+def ofNullable(elem):
+    &#39;&#39;&#39;
+    Returns an Optional describing the given value, if non-null, otherwise returns an empty Optional.
 
+    :param T elem: the possibly-null value to describe
+    :return: an Optional with a present value if the specified value is non-null, otherwise an empty Optional
+    &#39;&#39;&#39;
+    return Optional(elem)</code></pre>
+</details>
+</dd>
+</dl>
+<h3>Methods</h3>
+<dl>
+<dt id="stream.util.optional.Optional.filter"><code class="name flex">
+<span>def <span class="ident">filter</span></span>(<span>self, predicate)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.</p>
+<p>:param Predicate predicate: the predicate to apply to a value, if present
+:return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def filter(self, predicate):
+    &#39;&#39;&#39;
+    If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.
 
-                            </div>
-                            <div id="Optional.get" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.get">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">get</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">get</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns the value, otherwise raise an Exception.</span>
-
-<span class="sd">        :return: the non-null value described by this Optional</span>
-<span class="sd">        :raise: Exception if no value is present</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isEmpty</span><span class="p">():</span>
-            <span class="k">raise</span> <span class="ne">Exception</span><span class="p">(</span><span class="s2">&quot;Optional Empty&quot;</span><span class="p">)</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>If a value is present, returns the value, otherwise raise an Exception.</p>
-
+    :param Predicate predicate: the predicate to apply to a value, if present
+    :return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional
+    &#39;&#39;&#39;
+    if self.isPresent() and predicate(self.get()):
+        return self
+    else:
+        return Optional.empty()</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.get"><code class="name flex">
+<span>def <span class="ident">get</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>If a value is present, returns the value, otherwise raise an Exception.</p>
 <p>:return: the non-null value described by this Optional
-:raise: Exception if no value is present</p>
-</div>
+:raise: Exception if no value is present</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def get(self):
+    &#39;&#39;&#39;
+    If a value is present, returns the value, otherwise raise an Exception.
 
-
-                            </div>
-                            <div id="Optional.isPresent" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.isPresent">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">isPresent</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">isPresent</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns true, otherwise false.</span>
-
-<span class="sd">        :return: true if a value is present, otherwise false</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="ow">not</span> <span class="bp">self</span><span class="o">.</span><span class="n">isEmpty</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>If a value is present, returns true, otherwise false.</p>
-
-<p>:return: true if a value is present, otherwise false</p>
-</div>
-
-
-                            </div>
-                            <div id="Optional.isEmpty" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.isEmpty">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">isEmpty</span><span class="signature">(self)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">isEmpty</span><span class="p">(</span><span class="bp">self</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is not present, returns true, otherwise false.</span>
-
-<span class="sd">        :return: true if a value is not present, otherwise false</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">return</span> <span class="bp">self</span><span class="o">.</span><span class="n">__elem</span> <span class="ow">is</span> <span class="kc">None</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>If a value is not present, returns true, otherwise false.</p>
-
-<p>:return: true if a value is not present, otherwise false</p>
-</div>
-
-
-                            </div>
-                            <div id="Optional.ifPresent" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.ifPresent">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">ifPresent</span><span class="signature">(self, action)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">ifPresent</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">action</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, performs the given action with the value, otherwise does nothing.</span>
-
-<span class="sd">        :param Function action: the action to be performed, if a value is present</span>
-<span class="sd">        :raise Exception if value is present and the given action is null</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="n">action</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">())</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>If a value is present, performs the given action with the value, otherwise does nothing.</p>
-
+    :return: the non-null value described by this Optional
+    :raise: Exception if no value is present
+    &#39;&#39;&#39;
+    if self.isEmpty():
+        raise Exception(&#34;Optional Empty&#34;)
+    return self.__elem</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.ifPresent"><code class="name flex">
+<span>def <span class="ident">ifPresent</span></span>(<span>self, action)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>If a value is present, performs the given action with the value, otherwise does nothing.</p>
 <p>:param Function action: the action to be performed, if a value is present
-:raise Exception if value is present and the given action is null</p>
-</div>
+:raise Exception if value is present and the given action is null</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def ifPresent(self, action):
+    &#39;&#39;&#39;
+    If a value is present, performs the given action with the value, otherwise does nothing.
 
-
-                            </div>
-                            <div id="Optional.ifPresentOrElse" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.ifPresentOrElse">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">ifPresentOrElse</span><span class="signature">(self, action, emptyAction)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">ifPresentOrElse</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">action</span><span class="p">,</span> <span class="n">emptyAction</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, performs the given action with the value, otherwise performs the given empty-based action.</span>
-
-<span class="sd">        :param Function action: the action to be performed, if a value is present</span>
-<span class="sd">        :param Function emptyAction: the empty-based action to be performed, if no value is present</span>
-<span class="sd">        :raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="n">action</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">())</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="n">emptyAction</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>If a value is present, performs the given action with the value, otherwise performs the given empty-based action.</p>
-
+    :param Function action: the action to be performed, if a value is present
+    :raise Exception if value is present and the given action is null
+    &#39;&#39;&#39;
+    if self.isPresent():
+        action(self.get())</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.ifPresentOrElse"><code class="name flex">
+<span>def <span class="ident">ifPresentOrElse</span></span>(<span>self, action, emptyAction)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>If a value is present, performs the given action with the value, otherwise performs the given empty-based action.</p>
 <p>:param Function action: the action to be performed, if a value is present
 :param Function emptyAction: the empty-based action to be performed, if no value is present
-:raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.</p>
-</div>
+:raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def ifPresentOrElse(self, action, emptyAction):
+    &#39;&#39;&#39;
+    If a value is present, performs the given action with the value, otherwise performs the given empty-based action.
 
+    :param Function action: the action to be performed, if a value is present
+    :param Function emptyAction: the empty-based action to be performed, if no value is present
+    :raise Exception if a value is present and the given action is null, or no value is present and the given empty-based action is null.
+    &#39;&#39;&#39;
+    if self.isPresent():
+        action(self.get())
+    else:
+        emptyAction()</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.isEmpty"><code class="name flex">
+<span>def <span class="ident">isEmpty</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>If a value is not present, returns true, otherwise false.</p>
+<p>:return: true if a value is not present, otherwise false</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def isEmpty(self):
+    &#39;&#39;&#39;
+    If a value is not present, returns true, otherwise false.
 
-                            </div>
-                            <div id="Optional.filter" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.filter">#&nbsp;&nbsp</a>
+    :return: true if a value is not present, otherwise false
+    &#39;&#39;&#39;
+    return self.__elem is None</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.isPresent"><code class="name flex">
+<span>def <span class="ident">isPresent</span></span>(<span>self)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>If a value is present, returns true, otherwise false.</p>
+<p>:return: true if a value is present, otherwise false</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def isPresent(self):
+    &#39;&#39;&#39;
+    If a value is present, returns true, otherwise false.
 
-        
-            <span class="def">def</span>
-            <span class="name">filter</span><span class="signature">(self, predicate)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">filter</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">predicate</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.</span>
-
-<span class="sd">        :param Predicate predicate: the predicate to apply to a value, if present</span>
-<span class="sd">        :return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">()</span> <span class="ow">and</span> <span class="n">predicate</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">()):</span>
-            <span class="k">return</span> <span class="bp">self</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.</p>
-
-<p>:param Predicate predicate: the predicate to apply to a value, if present
-:return: an Optional describing the value of this Optional, if a value is present and the value matches the given predicate, otherwise an empty Optional</p>
-</div>
-
-
-                            </div>
-                            <div id="Optional.map" class="classattr">
-                                        <div class="attr function"><a class="headerlink" href="#Optional.map">#&nbsp;&nbsp</a>
-
-        
-            <span class="def">def</span>
-            <span class="name">map</span><span class="signature">(self, mapper)</span>:
-    </div>
-
-                <details>
-            <summary>View Source</summary>
-            <div class="codehilite"><pre><span></span>    <span class="k">def</span> <span class="nf">map</span><span class="p">(</span><span class="bp">self</span><span class="p">,</span> <span class="n">mapper</span><span class="p">):</span>
-        <span class="sd">&#39;&#39;&#39;</span>
-<span class="sd">        If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional. </span>
-<span class="sd">        If the mapping function returns a null result then this method returns an empty Optional.</span>
-
-<span class="sd">        :param Mapper mapper: the mapping function to apply to a value, if present</span>
-<span class="sd">        :return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional</span>
-<span class="sd">        &#39;&#39;&#39;</span>
-        <span class="k">if</span> <span class="bp">self</span><span class="o">.</span><span class="n">isPresent</span><span class="p">():</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">ofNullable</span><span class="p">(</span><span class="n">mapper</span><span class="p">(</span><span class="bp">self</span><span class="o">.</span><span class="n">get</span><span class="p">()))</span>
-        <span class="k">else</span><span class="p">:</span>
-            <span class="k">return</span> <span class="n">Optional</span><span class="o">.</span><span class="n">empty</span><span class="p">()</span>
-</pre></div>
-
-        </details>
-
-            <div class="docstring"><p>If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional. 
+    :return: true if a value is present, otherwise false
+    &#39;&#39;&#39;
+    return not self.isEmpty()</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.map"><code class="name flex">
+<span>def <span class="ident">map</span></span>(<span>self, mapper)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional.
 If the mapping function returns a null result then this method returns an empty Optional.</p>
-
 <p>:param Mapper mapper: the mapping function to apply to a value, if present
-:return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional</p>
+:return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def map(self, mapper):
+    &#39;&#39;&#39;
+    If a value is present, returns an Optional describing (as if by ofNullable(T)) the result of applying the given mapping function to the value, otherwise returns an empty Optional. 
+    If the mapping function returns a null result then this method returns an empty Optional.
+
+    :param Mapper mapper: the mapping function to apply to a value, if present
+    :return: an Optional describing the result of applying a mapping function to the value of this Optional, if a value is present, otherwise an empty Optional
+    &#39;&#39;&#39;
+    if self.isPresent():
+        return Optional.ofNullable(mapper(self.get()))
+    else:
+        return Optional.empty()</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.orElse"><code class="name flex">
+<span>def <span class="ident">orElse</span></span>(<span>self, value)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns the value if present, or a provided argument otherwise. It's a safe alternative to get() method.</p>
+<p>:return: the non-null value described by this Optional or the value passed as an argument</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def orElse(self, value):
+    &#39;&#39;&#39;
+    Returns the value if present, or a provided argument otherwise. It&#39;s a safe alternative to get() method.
+
+    :return: the non-null value described by this Optional or the value passed as an argument
+    &#39;&#39;&#39;
+    return self.__elem if self.isPresent() else value</code></pre>
+</details>
+</dd>
+<dt id="stream.util.optional.Optional.orElseGet"><code class="name flex">
+<span>def <span class="ident">orElseGet</span></span>(<span>self, supplier)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Returns either a stored value, or calls a supplier otherwise. It's a safe alternative to get() method.</p>
+<p>:return: the non-null value described by this Optional or the result of supplier argument</p></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def orElseGet(self, supplier):
+    &#39;&#39;&#39;
+    Returns either a stored value, or calls a supplier otherwise. It&#39;s a safe alternative to get() method.
+
+    :return: the non-null value described by this Optional or the result of supplier argument
+    &#39;&#39;&#39;
+    return self.__elem if self.isPresent() else supplier()</code></pre>
+</details>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul></ul>
 </div>
-
-
-                            </div>
-                </section>
-    </main>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="stream.util" href="index.html">stream.util</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="stream.util.optional.Optional" href="#stream.util.optional.Optional">Optional</a></code></h4>
+<ul class="two-column">
+<li><code><a title="stream.util.optional.Optional.empty" href="#stream.util.optional.Optional.empty">empty</a></code></li>
+<li><code><a title="stream.util.optional.Optional.filter" href="#stream.util.optional.Optional.filter">filter</a></code></li>
+<li><code><a title="stream.util.optional.Optional.get" href="#stream.util.optional.Optional.get">get</a></code></li>
+<li><code><a title="stream.util.optional.Optional.ifPresent" href="#stream.util.optional.Optional.ifPresent">ifPresent</a></code></li>
+<li><code><a title="stream.util.optional.Optional.ifPresentOrElse" href="#stream.util.optional.Optional.ifPresentOrElse">ifPresentOrElse</a></code></li>
+<li><code><a title="stream.util.optional.Optional.isEmpty" href="#stream.util.optional.Optional.isEmpty">isEmpty</a></code></li>
+<li><code><a title="stream.util.optional.Optional.isPresent" href="#stream.util.optional.Optional.isPresent">isPresent</a></code></li>
+<li><code><a title="stream.util.optional.Optional.map" href="#stream.util.optional.Optional.map">map</a></code></li>
+<li><code><a title="stream.util.optional.Optional.of" href="#stream.util.optional.Optional.of">of</a></code></li>
+<li><code><a title="stream.util.optional.Optional.ofNullable" href="#stream.util.optional.Optional.ofNullable">ofNullable</a></code></li>
+<li><code><a title="stream.util.optional.Optional.orElse" href="#stream.util.optional.Optional.orElse">orElse</a></code></li>
+<li><code><a title="stream.util.optional.Optional.orElseGet" href="#stream.util.optional.Optional.orElseGet">orElseGet</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc" title="pdoc: Python API documentation generator"><cite>pdoc</cite> 0.10.0</a>.</p>
+</footer>
 </body>
 </html>

--- a/stream/stream.py
+++ b/stream/stream.py
@@ -1,5 +1,4 @@
 from functools import cmp_to_key
-import random
 
 from .util.iterators import IteratorUtils
 from .util.optional import Optional
@@ -47,6 +46,7 @@ class Stream():
         return Stream(iter([elem]))
 
     @staticmethod
+    # skipcq: PYL-E0102
     def of(*elements):
         '''
         Returns a sequential ordered stream whose elements are the specified values.
@@ -256,12 +256,21 @@ class Stream():
         '''
         return not self.anyMatch(predicate)
 
-    def findFirst(self):
-        '''
-        Returns an Optional describing the first element of this stream, or an empty Optional if the stream is empty. If the stream has no encounter order, then any element may be returned.
+    def findFirst(self, predicate=None):
+        """
+        Returns an Optional describing the first element
+        (with optional filtering by a given predicate) of this stream,
+        or an empty Optional if the stream is empty.
+        If the stream has no encounter order, then any element may be returned.
 
-        :return: an Optional describing the first element of this stream, or an empty Optional if the stream is empty
-        '''
+        :param Predicate predicate: optional predicate to apply to elements
+        of this stream
+        :return: an Optional describing the first element of this stream,
+        or an empty Optional if the stream is empty
+        """
+        if predicate:
+            self.filter(predicate)
+
         for elem in self.iterable:
             return Optional.of(elem)
         return Optional.ofNullable(None)

--- a/stream/util/optional.py
+++ b/stream/util/optional.py
@@ -99,6 +99,26 @@ class Optional:
         else:
             emptyAction()
 
+    def orElse(self, value):
+        """
+        Returns the value if present, or a provided argument otherwise.
+        It's a safe alternative to get() method.
+
+        :return: the non-null value described by this Optional
+        or the value passed as an argument.
+        """
+        return self.__elem if self.isPresent() else value
+
+    def orElseGet(self, supplier):
+        """
+        Returns either a stored value, or calls a supplier otherwise.
+        It's a safe alternative to get() method.
+
+        :return: the non-null value described by this Optional
+        or the result of supplier argument.
+        """
+        return self.__elem if self.isPresent() else supplier()
+
     def filter(self, predicate):
         '''
         If a value is present, and the value matches the given predicate, returns an Optional describing the value, otherwise returns an empty Optional.


### PR DESCRIPTION
- Added new `orElse` and `orElseGet` API to `Optional` class to follow the original Java style
- Adjusted `Stream`'s `findFirst` API to support predicate to follow the original Java style
- Update py docs with newly added API
- Added new ignorable items

Fixes #2

@alemazzo note that there were some DeepSource violations in the existing code. E.g. Stream's `of` API. As python doesn't welcome a Java-like overloading style, it has to be either refactored or ignored. I temporarily ignored this rule for the 49th line.